### PR TITLE
refrsh token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "cache-manager": "^6.4.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "cookie-parser": "^1.4.7",
         "ethers": "^5.8.0",
         "iconv-lite": "0.6.3",
         "nestjs-typeorm-paginate": "^4.1.0",
@@ -3650,7 +3651,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.2.tgz",
       "integrity": "sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==",
-      "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.7",
         "dotenv-expand": "12.0.1",
@@ -7671,6 +7671,23 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -12937,7 +12954,6 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
       "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cache-manager": "^6.4.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "cookie-parser": "^1.4.7",
     "ethers": "^5.8.0",
     "iconv-lite": "0.6.3",
     "nestjs-typeorm-paginate": "^4.1.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { BlacklistModule } from './blacklist/blacklist.module';
 import { RateLockModule } from './ratelock/ratelock.module';
 import { WalletModule } from './wallet/wallet.module';
 import { RateLocksCron } from './ratelock/rate-locks.cron';
+import { EmailService } from './common/utils/email.service';
 
 @Module({
   imports: [
@@ -87,7 +88,8 @@ import { RateLocksCron } from './ratelock/rate-locks.cron';
       provide: APP_GUARD,
       useClass: ThrottlerGuard,
     },
+    EmailService,
   ],
-  exports: [AppService],
+  exports: [AppService, EmailService],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,7 +5,10 @@ import {
   UseGuards,
   Request,
   Req,
+  Res,
+  UnauthorizedException,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { AuthService } from './services/auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -13,11 +16,16 @@ import { RefreshTokenDto } from './dto/refresh.token.dto';
 import { JwtAuthGuard } from './guard/jwt.auth.guard';
 import { ThrottleAuth } from 'src/common/decorators/throttle-auth.decorators';
 import { LinkWalletDto } from './dto/link-wallet.dto';
+import { UserService } from 'src/user/providers/user.service';
+import { JwtRefreshGuard } from './guard/jwt.refresh.guard';
 
 @Controller('auth')
 @ThrottleAuth()
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly userService: UserService,
+  ) {}
 
   //Register Route
   @Post('register')
@@ -63,5 +71,43 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   getProfile(@Request() req) {
     return req.user;
+  }
+
+  @Post('reuest-otp')
+  async requestOtp(@Body('email') email: string) {
+    await this.authService.reuestOtp(email);
+    return { message: 'OTP sent to email' };
+  }
+
+  @Post('verify-otp')
+  async verifyOtp(
+    @Body() { email, code }: { email: string; code: string },
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const isValid = await this.authService.verifyOtp(email, code);
+    if (!isValid) throw new UnauthorizedException('Invalid or expired OTP');
+
+    const user = await this.userService.findOneByEmail(email);
+    const accessToken = this.authService.generateAccessToken(user);
+    const refreshToken = this.authService.generateRefreshToken(user);
+
+    await this.authService.storeRefreshToken(Number(user.id), refreshToken);
+
+    res.cookie('refresh_token', refreshToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      maxAge: 3 * 24 * 60 * 60 * 1000, // 3 days
+    });
+
+    return { accessToken };
+  }
+
+  @UseGuards(JwtRefreshGuard)
+  @Post('refresh')
+  async refreshtoken(@Req() req, @Res({ passthrough: true }) res: Response) {
+    const user = req.user;
+    const accessToken = this.authService.generateAccessToken(user);
+    res.json({ accessToken });
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { AuthService } from './services/auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { UserModule } from 'src/user/user.module';
 import { BcryptPasswordHashingService } from './services/bcrypt-password-hashing.service';
+import { AuthService } from './auth.service';
 
 @Module({
   imports: [

--- a/src/auth/guard/jwt.refresh.guard.ts
+++ b/src/auth/guard/jwt.refresh.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtRefreshGuard extends AuthGuard('jwt-refresh') {}

--- a/src/common/jwt/jwt-refresh.strategy.ts
+++ b/src/common/jwt/jwt-refresh.strategy.ts
@@ -1,0 +1,34 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { UserService } from 'src/user/providers/user.service';
+import * as bcrypt from 'bcrypt';
+import { Request } from 'express';
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-refresh',
+) {
+  constructor(private readonly usersService: UserService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req: Request) => req?.cookies?.['refresh_token'],
+      ]),
+      secretOrKey: process.env.REFRESH_TOKEN_SECRET!,
+      passReqToCallback: true,
+    });
+  }
+
+  async validate(req: Request, payload: any) {
+    const refreshToken = req.cookies?.['refresh_token'];
+    const user = await this.usersService.findById(payload.sub);
+    const isValid = await bcrypt.compare(
+      refreshToken,
+      String(user.refreshToken),
+    );
+
+    if (!isValid) throw new UnauthorizedException();
+    return user;
+  }
+}

--- a/src/common/jwt/jwt.strategy.ts
+++ b/src/common/jwt/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy, ExtractJwt } from 'passport-jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserService } from 'src/user/providers/user.service';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(private readonly userservice: UserService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_SECRET!,
+    });
+  }
+
+  async validate(payload: any) {
+    return this.userservice.findById(payload.sub);
+  }
+}

--- a/src/common/utils/email.service.ts
+++ b/src/common/utils/email.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class EmailService {
+  private transporter: nodemailer.Transporter;
+
+  constructor(private configService: ConfigService) {
+    this.transporter = nodemailer.createTransport({
+      host: this.configService.get<string>('EMAIL_HOST'),
+      port: this.configService.get<number>('EMAIL_PORT'),
+      secure: false,
+      auth: {
+        user: this.configService.get<string>('EMAIL_USER'),
+        pass: this.configService.get<string>('EMAIL_PASS'),
+      },
+    });
+  }
+
+  async sendOtpEmail(to: string, otp: string) {
+    const info = await this.transporter.sendMail({
+      from: `"MyApp" <${this.configService.get('EMAIL_USER')}>`,
+      to,
+      subject: 'Your OTP Code',
+      text: `Your OTP code is: ${otp}. It expires in 5 minutes.`,
+    });
+
+    console.log('OTP email sent: %s', info.messageId);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,10 +7,11 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-
+  app.use(cookieParser());
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -81,3 +82,6 @@ async function bootstrap() {
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();
+function cookieParser(): any {
+  throw new Error('Function not implemented.');
+}

--- a/src/user/entities/otp.entity.ts
+++ b/src/user/entities/otp.entity.ts
@@ -1,0 +1,14 @@
+@Entity()
+export class Otp {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  email: string;
+
+  @Column()
+  code: string;
+
+  @Column()
+  expiresAt: Date;
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -99,6 +99,9 @@ export class User {
   @Column({ default: true })
   isActive: boolean;
 
+  @Column({ nullable: true })
+  refreshToken?: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/user/providers/user.service.ts
+++ b/src/user/providers/user.service.ts
@@ -70,4 +70,18 @@ export class UserService {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
   }
+
+  async updateRefreshToken(userId: number, hashedToken: string): Promise<void> {
+    await this.userRepository.update(userId, {
+      refreshToken: hashedToken,
+    });
+  }
+
+  async findById(id: number): Promise<User> {
+    const user = await this.userRepository.findOneBy({ id: String(id) });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${id} not found`);
+    }
+    return user;
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "typeRoots": ["./node_modules/@types", "./types"]
   }
 }

--- a/types/express.d.ts
+++ b/types/express.d.ts
@@ -1,0 +1,9 @@
+import { Request } from 'express';
+
+declare module 'express' {
+  export interface Request {
+    cookies: {
+      [key: string]: string;
+    };
+  }
+}


### PR DESCRIPTION
🔐 feat(auth): implement OTP-based login with JWT access & refresh tokens
📌 Summary
This PR replaces the email-password login with a secure OTP-based authentication system. On successful OTP verification, an access token (1h) is returned in the response body, and a refresh token (3d) is set as an HttpOnly, Secure cookie.

✅ Key Features
6-digit OTP generation and email delivery (email.service.ts)

OTP expiration after 5 minutes or single use

Access & refresh token generation using JWT

Refresh token stored hashed in DB and sent as cookie

POST /auth/refresh route for silent token refresh

Guards for protected routes using Passport strategies

🛠️ Modified Files
auth.controller.ts, auth.service.ts, auth.module.ts

common/jwt/jwt.strategy.ts, jwt-refresh.strategy.ts

common/utils/email.service.ts

close #128




user/user.entity.ts, user.service.ts

.env, migration for refresh tokens


close #128