### PR TITLE
feat(auth): implement Mailgun OTP email delivery service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,8 @@ STELLAR_BASE_FEE=100
 
 # Wallet encryption (generate with: openssl rand -hex 32)
 WALLET_ENCRYPTION_KEY=your-64-char-hex-key-for-wallet-encryption-change-in-production
+MAILGUN_API_KEY=
+MAILGUN_DOMAIN=
+MAILGUN_FROM_EMAIL=noreply@yourdomain.com
+MAILGUN_FROM_NAME=NexaFX
+SKIP_EMAIL_SENDING=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "form-data": "^4.0.5",
+        "mailgun.js": "^12.7.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.13.1",
@@ -47,6 +49,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.7",
+        "@types/nodemailer": "^7.0.11",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
@@ -2992,6 +2995,150 @@
         }
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz",
+      "integrity": "sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
+      "integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
+      "integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
+      "integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
+      "integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
+      "integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
+      "integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
+      "integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
+      "integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-win32-x64-msvc": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
@@ -3323,6 +3470,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/passport": {
@@ -4802,6 +4959,12 @@
       "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
       "license": "Apache-2.0",
       "optional": true
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -6972,6 +7135,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -8834,6 +9012,20 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/mailgun.js": {
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-12.7.0.tgz",
+      "integrity": "sha512-TKuGxSGMdGKQDR+Ciocs0zzKNsy+ip+BwLEVatVLlJls30OigFcK61LiBBWoPrVg5D5nmKN/nDR9yKLJCERCsA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.1",
+        "base-64": "^1.0.0",
+        "url-join": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/make-dir": {
@@ -12241,6 +12433,12 @@
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "license": "MIT"
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "form-data": "^4.0.5",
+    "mailgun.js": "^12.7.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.13.1",
@@ -43,10 +45,10 @@
     "rxjs": "^7.8.1",
     "stellar-sdk": "^13.3.0",
     "swagger-ui-express": "^5.0.1",
-    "typeorm": "^0.3.20",
-    "typescript": "^5.7.3",
     "ts-node": "^10.9.2",
-    "tsconfig-paths": "^4.2.0"
+    "tsconfig-paths": "^4.2.0",
+    "typeorm": "^0.3.20",
+    "typescript": "^5.7.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -58,6 +60,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
+    "@types/nodemailer": "^7.0.11",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -14,6 +14,7 @@ import { StellarModule } from '../blockchain/stellar/stellar.module';
 
 @Module({
   imports: [
+    ConfigModule,
     UsersModule,
     OtpsModule,
     TokensModule,

--- a/src/auth/email/otp-delivery.service.ts
+++ b/src/auth/email/otp-delivery.service.ts
@@ -1,13 +1,181 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Mailgun from 'mailgun.js';
+import FormData from 'form-data';
 import { OtpType } from '../../otps/otp.entity';
+
+interface SendOtpParams {
+  email: string;
+  type: OtpType;
+  otp: string;
+}
+
+interface EmailTemplate {
+  subject: string;
+  html: string;
+  text: string;
+}
 
 @Injectable()
 export class OtpDeliveryService {
-  async sendOtp(params: {
-    email: string;
-    type: OtpType;
-    otp: string;
-  }): Promise<void> {
-    void params;
+  private readonly logger = new Logger(OtpDeliveryService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async sendOtp(params: SendOtpParams): Promise<void> {
+    const skipEmail = this.configService.get<string>('SKIP_EMAIL_SENDING');
+
+    if (skipEmail === 'true') {
+      this.logger.log(
+        `[OTP DEV] Email skipped — ${params.type} OTP for ${params.email}: ${params.otp}`,
+      );
+      return;
+    }
+
+    try {
+      const template = this.buildTemplate(params.type, params.otp);
+      await this.sendEmail(params.email, template);
+      this.logger.log(
+        `[OTP] ${params.type} email sent successfully to ${params.email}`,
+      );
+    } catch (error) {
+      // Log but do not throw — email failure must never crash the auth flow
+      this.logger.error(
+        `[OTP] Failed to send ${params.type} email to ${params.email}`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private buildTemplate(type: OtpType, otp: string): EmailTemplate {
+    const expiry = '10 minutes';
+
+    const baseStyles = `
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 480px;
+      margin: 0 auto;
+      background: #ffffff;
+    `;
+
+    const codeBlock = `
+      <div style="background: #FFF8E7; border: 2px solid #F5A623; border-radius: 12px;
+                  text-align: center; padding: 24px; margin: 24px 0;">
+        <p style="margin: 0 0 8px; font-size: 13px; color: #666; text-transform: uppercase;
+                  letter-spacing: 1px;">Your verification code</p>
+        <p style="margin: 0; font-size: 40px; font-weight: 700; letter-spacing: 10px;
+                  color: #1A1A1A;">${otp}</p>
+        <p style="margin: 8px 0 0; font-size: 12px; color: #999;">
+          Expires in ${expiry}
+        </p>
+      </div>
+    `;
+
+    const footer = `
+      <p style="font-size: 12px; color: #999; text-align: center; margin-top: 32px;">
+        If you did not request this, please ignore this email.<br/>
+        This code is confidential — do not share it with anyone.
+      </p>
+      <p style="font-size: 12px; color: #ccc; text-align: center;">
+        © ${new Date().getFullYear()} NexaFX. All rights reserved.
+      </p>
+    `;
+
+    const templates: Record<OtpType, EmailTemplate> = {
+      [OtpType.SIGNUP]: {
+        subject: 'Verify your NexaFX account',
+        html: `
+          <div style="${baseStyles}">
+            <div style="background: #F5A623; padding: 24px; border-radius: 12px 12px 0 0; text-align: center;">
+              <h1 style="margin: 0; color: #fff; font-size: 24px; font-weight: 700;">NexaFX</h1>
+            </div>
+            <div style="padding: 32px;">
+              <h2 style="margin: 0 0 8px; font-size: 20px; color: #1A1A1A;">Welcome to NexaFX 👋</h2>
+              <p style="color: #555; line-height: 1.6;">
+                Thanks for signing up. Use the code below to verify your account.
+              </p>
+              ${codeBlock}
+              ${footer}
+            </div>
+          </div>
+        `,
+        text: `Welcome to NexaFX!\n\nYour signup verification code is: ${otp}\n\nThis code expires in ${expiry}.\n\nIf you did not sign up for NexaFX, please ignore this email.`,
+      },
+
+      [OtpType.LOGIN]: {
+        subject: 'Your NexaFX login code',
+        html: `
+          <div style="${baseStyles}">
+            <div style="background: #F5A623; padding: 24px; border-radius: 12px 12px 0 0; text-align: center;">
+              <h1 style="margin: 0; color: #fff; font-size: 24px; font-weight: 700;">NexaFX</h1>
+            </div>
+            <div style="padding: 32px;">
+              <h2 style="margin: 0 0 8px; font-size: 20px; color: #1A1A1A;">Login verification</h2>
+              <p style="color: #555; line-height: 1.6;">
+                A login attempt was made to your NexaFX account. Use the code below to continue.
+              </p>
+              ${codeBlock}
+              <p style="color: #e74c3c; font-size: 13px; background: #FFF0F0; padding: 12px;
+                         border-radius: 8px; border-left: 3px solid #e74c3c;">
+                ⚠️ If you did not attempt to log in, change your password immediately.
+              </p>
+              ${footer}
+            </div>
+          </div>
+        `,
+        text: `NexaFX Login Code\n\nYour login verification code is: ${otp}\n\nThis code expires in ${expiry}.\n\nIf you did not attempt to log in, please secure your account immediately.`,
+      },
+
+      [OtpType.PASSWORD_RESET]: {
+        subject: 'Reset your NexaFX password',
+        html: `
+          <div style="${baseStyles}">
+            <div style="background: #F5A623; padding: 24px; border-radius: 12px 12px 0 0; text-align: center;">
+              <h1 style="margin: 0; color: #fff; font-size: 24px; font-weight: 700;">NexaFX</h1>
+            </div>
+            <div style="padding: 32px;">
+              <h2 style="margin: 0 0 8px; font-size: 20px; color: #1A1A1A;">Password reset request</h2>
+              <p style="color: #555; line-height: 1.6;">
+                We received a request to reset your NexaFX password. Use the code below to proceed.
+              </p>
+              ${codeBlock}
+              <p style="color: #e74c3c; font-size: 13px; background: #FFF0F0; padding: 12px;
+                         border-radius: 8px; border-left: 3px solid #e74c3c;">
+                ⚠️ If you did not request a password reset, your account may be at risk.
+                Contact support immediately.
+              </p>
+              ${footer}
+            </div>
+          </div>
+        `,
+        text: `NexaFX Password Reset\n\nYour password reset code is: ${otp}\n\nThis code expires in ${expiry}.\n\nIf you did not request a password reset, please secure your account immediately.`,
+      },
+    };
+
+    return templates[type];
+  }
+
+  private async sendEmail(to: string, template: EmailTemplate): Promise<void> {
+    const apiKey = this.configService.get<string>('MAILGUN_API_KEY');
+    const domain = this.configService.get<string>('MAILGUN_DOMAIN');
+    const fromEmail = this.configService.get<string>('MAILGUN_FROM_EMAIL');
+    const fromName =
+      this.configService.get<string>('MAILGUN_FROM_NAME') ?? 'NexaFX';
+
+    if (!apiKey || !domain || !fromEmail) {
+      throw new Error(
+        'Missing Mailgun configuration: MAILGUN_API_KEY, MAILGUN_DOMAIN, and MAILGUN_FROM_EMAIL are required',
+      );
+    }
+
+    const mailgun = new Mailgun(FormData);
+    const client = mailgun.client({ username: 'api', key: apiKey });
+
+    await client.messages.create(domain, {
+      from: `${fromName} <${fromEmail}>`,
+      to: [to],
+      subject: template.subject,
+      html: template.html,
+      text: template.text,
+    });
   }
 }


### PR DESCRIPTION
PR Description
The OtpDeliveryService was an empty stub silently discarding every call, making signup, login, forgot password, and resend OTP completely non-functional. This PR implements the real Mailgun integration, adds a distinct branded HTML email per OTP type, and respects a SKIP_EMAIL_SENDING dev flag. Email failures are caught and logged — they never throw or break the auth flow.
Files changed: src/auth/email/otp-delivery.service.ts, src/auth/auth.module.ts, package.json

closes #225 