### PR TITLE
fix(notifications): extract userId from JWT and complete request decorators (#209)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
       "json",
       "ts"
     ],
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {

--- a/src/notifications/dto/batch-notification.dto.ts
+++ b/src/notifications/dto/batch-notification.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsUUID, IsEnum, IsOptional } from 'class-validator';
+import { IsArray, IsUUID, IsEnum } from 'class-validator';
 import { NotificationStatus } from '../entities/notification.entity';
 
 export class BatchMarkAsReadDto {
@@ -22,8 +22,4 @@ export class BatchUpdateStatusDto {
   status: NotificationStatus;
 }
 
-export class MarkAllAsReadDto {
-  @IsOptional()
-  @IsUUID()
-  userId: string;
-}
+export class MarkAllAsReadDto {}

--- a/src/notifications/dto/notification-response.dto.ts
+++ b/src/notifications/dto/notification-response.dto.ts
@@ -1,4 +1,7 @@
-import { NotificationType, NotificationStatus } from '../entities/notification.entity';
+import {
+  NotificationType,
+  NotificationStatus,
+} from '../entities/notification.entity';
 
 export class NotificationResponseDto {
   id: string;

--- a/src/notifications/dto/update-notification.dto.ts
+++ b/src/notifications/dto/update-notification.dto.ts
@@ -1,6 +1,4 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateNotificationDto } from './create-notification.dto';
 
-export class UpdateNotificationDto extends PartialType(
-  CreateNotificationDto,
-) {}
+export class UpdateNotificationDto extends PartialType(CreateNotificationDto) {}

--- a/src/notifications/entities/notification.entity.ts
+++ b/src/notifications/entities/notification.entity.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import {
   Entity,
   Column,

--- a/src/notifications/notifications.controller.spec.ts
+++ b/src/notifications/notifications.controller.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { CurrentUserPayload } from '../auth/decorators/current-user.decorator';
+
+describe('NotificationsController', () => {
+  let controller: NotificationsController;
+
+  const mockService = {
+    findAll: jest.fn(),
+    getUnreadCount: jest.fn(),
+    markAllAsRead: jest.fn(),
+    deleteAllByUser: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationsController],
+      providers: [
+        {
+          provide: NotificationsService,
+          useValue: mockService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get(NotificationsController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should extract userId from CurrentUser decorator', async () => {
+    const user: CurrentUserPayload = {
+      userId: 'user-123',
+      email: 'test@example.com',
+      role: 'USER',
+    };
+
+    await controller.findAll(user, 1, 10);
+
+    expect(mockService.findAll).toHaveBeenCalledWith(
+      'user-123',
+      1,
+      10,
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -41,6 +41,21 @@ export class NotificationsService {
       throw new BadRequestException('Failed to create notification');
     }
   }
+  async updateBatchStatus(
+    notificationIds: string[],
+    status: NotificationStatus,
+  ): Promise<{ updated: number }> {
+    if (!notificationIds || notificationIds.length === 0) {
+      throw new BadRequestException('Notification IDs are required');
+    }
+
+    const result = await this.notificationsRepository.update(
+      { id: In(notificationIds) },
+      { status },
+    );
+
+    return { updated: result.affected || 0 };
+  }
 
   async findAll(
     userId: string,


### PR DESCRIPTION
## Description

This PR fixes the `NotificationsController` runtime issues by properly sourcing `userId` from the authenticated JWT payload and completing missing request decorators.

User identity is now extracted via `@CurrentUser()` instead of being passed as a plain parameter, ensuring that all notification operations are scoped to the authenticated user.

## Related Issue

Closes #209

## Changes Made

- Extracted `userId` from verified JWT payload using `@CurrentUser()`
- Added missing `@Body()` decorators for DTO-based routes
- Added missing `@Param('id')` decorators for single-resource routes
- Applied `@UseGuards(JwtAuthGuard)` and `@ApiBearerAuth()` to protect endpoints
- Updated controller unit tests to validate user context extraction

## Result

- All notification endpoints now correctly enforce authenticated user context
- Identity is no longer sourced from unvalidated request data
- Controller behavior is consistent with other secured modules