### PR TITLE
Fix scheduled cron registration on Render

### DIFF
--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('AppModule', () => {
+  it('registers ScheduleModule.forRoot() at the application root', () => {
+    const moduleSource = readFileSync(join(__dirname, 'app.module.ts'), 'utf8');
+
+    expect(moduleSource).toContain('ScheduleModule.forRoot()');
+  });
+});

--- a/src/scheduled-jobs/scheduled-jobs.module.spec.ts
+++ b/src/scheduled-jobs/scheduled-jobs.module.spec.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('ScheduledJobsModule', () => {
+  it('does not import ScheduleModule directly', () => {
+    const moduleSource = readFileSync(
+      join(__dirname, 'scheduled-jobs.module.ts'),
+      'utf8',
+    );
+
+    expect(moduleSource).not.toContain('ScheduleModule');
+  });
+});

--- a/src/scheduled-jobs/scheduled-jobs.module.ts
+++ b/src/scheduled-jobs/scheduled-jobs.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ScheduleModule } from '@nestjs/schedule';
 import { ScheduledJobsService } from './scheduled-jobs.service';
 import { Transaction } from '../transactions/entities/transaction.entity';
 import { TransactionsModule } from '../transactions/transaction.module';
@@ -12,7 +11,6 @@ import { RateAlertsModule } from '../rate-alerts/rate-alerts.module';
 
 @Module({
   imports: [
-    ScheduleModule,
     TypeOrmModule.forFeature([Transaction, Notification]),
     TransactionsModule,
     BlockchainModule,

--- a/src/scheduled-jobs/scheduled-jobs.service.spec.ts
+++ b/src/scheduled-jobs/scheduled-jobs.service.spec.ts
@@ -1,11 +1,14 @@
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { ScheduledJobsService } from './scheduled-jobs.service';
 import {
   Transaction,
   TransactionStatus,
-  TransactionType,
 } from '../transactions/entities/transaction.entity';
 import { Notification } from '../notifications/entities/notification.entity';
 import { TransactionsService } from '../transactions/services/transaction.service';
@@ -16,7 +19,6 @@ import { RateAlertsService } from '../rate-alerts/rate-alerts.service';
 
 describe('ScheduledJobsService', () => {
   let service: ScheduledJobsService;
-  let transactionRepository: Repository<Transaction>;
 
   const mockTransactionRepository = {
     find: jest.fn(),
@@ -26,13 +28,18 @@ describe('ScheduledJobsService', () => {
 
   const mockNotificationRepository = {
     find: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockTransactionsService = {};
   const mockStellarService = {};
   const mockNotificationsService = {};
-  const mockUsersService = {};
-  const mockRateAlertsService = {};
+  const mockUsersService = {
+    syncWalletBalanceSnapshots: jest.fn(),
+  };
+  const mockRateAlertsService = {
+    checkAndTriggerAlerts: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -70,13 +77,60 @@ describe('ScheduledJobsService', () => {
     }).compile();
 
     service = module.get<ScheduledJobsService>(ScheduledJobsService);
-    transactionRepository = module.get<Repository<Transaction>>(
-      getRepositoryToken(Transaction),
-    );
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('cron handlers', () => {
+    it.each([
+      ['syncWalletBalances', () => service.syncWalletBalances()],
+      [
+        'reconcilePendingTransactions',
+        () => service.reconcilePendingTransactions(),
+      ],
+      ['retryFailedTransactions', () => service.retryFailedTransactions()],
+      ['checkRateAlerts', () => service.checkRateAlerts()],
+      ['cleanupOldNotifications', () => service.cleanupOldNotifications()],
+      [
+        'syncWalletBalancesSnapshot',
+        () => service.syncWalletBalancesSnapshot(),
+      ],
+    ])('%s is directly callable without throwing', async (_name, callCron) => {
+      const deleteQueryBuilder = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 0 }),
+      };
+      const claimQueryBuilder = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 0 }),
+      };
+
+      mockTransactionRepository.createQueryBuilder.mockReturnValue(
+        claimQueryBuilder,
+      );
+      mockTransactionRepository.find.mockResolvedValue([]);
+      mockNotificationRepository.createQueryBuilder.mockReturnValue(
+        deleteQueryBuilder,
+      );
+      mockUsersService.syncWalletBalanceSnapshots.mockResolvedValue({
+        processed: 0,
+        updated: 0,
+        failed: 0,
+      });
+      mockRateAlertsService.checkAndTriggerAlerts.mockResolvedValue({
+        checked: 0,
+        triggered: 0,
+        reactivated: 0,
+      });
+
+      await expect(callCron()).resolves.toBeUndefined();
+    });
   });
 
   describe('claimPendingTransactions', () => {
@@ -105,17 +159,22 @@ describe('ScheduledJobsService', () => {
       const result = await service['claimPendingTransactions']();
 
       expect(mockQueryBuilder.update).toHaveBeenCalledWith(Transaction);
-      expect(mockQueryBuilder.set).toHaveBeenCalledWith({
-        processingLockedAt: expect.any(Date),
-        processingLockedBy: expect.any(String),
-      });
-      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+      const [claimSetPayload] = mockQueryBuilder.set.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(claimSetPayload.processingLockedAt).toBeInstanceOf(Date);
+      expect(typeof claimSetPayload.processingLockedBy).toBe('string');
+
+      const whereCall = mockQueryBuilder.where.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      const [whereClause, whereParams] = whereCall;
+      expect(whereClause).toBe(
         'status = :status AND ("processingLockedAt" IS NULL OR "processingLockedAt" < :expiry)',
-        expect.objectContaining({
-          status: TransactionStatus.PENDING,
-          expiry: expect.any(Date),
-        }),
       );
+      expect(whereParams.status).toBe(TransactionStatus.PENDING);
+      expect(whereParams.expiry).toBeInstanceOf(Date);
       expect(result).toEqual(mockTransactions);
     });
 
@@ -155,18 +214,23 @@ describe('ScheduledJobsService', () => {
       const result = await service['claimTransactionForRetry'](transactionId);
 
       expect(mockQueryBuilder.update).toHaveBeenCalledWith(Transaction);
-      expect(mockQueryBuilder.set).toHaveBeenCalledWith({
-        processingLockedAt: expect.any(Date),
-        processingLockedBy: expect.any(String),
-      });
-      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+      const [retrySetPayload] = mockQueryBuilder.set.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(retrySetPayload.processingLockedAt).toBeInstanceOf(Date);
+      expect(typeof retrySetPayload.processingLockedBy).toBe('string');
+
+      const whereCall = mockQueryBuilder.where.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      const [whereClause, whereParams] = whereCall;
+      expect(whereClause).toBe(
         'id = :id AND status = :status AND ("processingLockedAt" IS NULL OR "processingLockedAt" < :expiry)',
-        expect.objectContaining({
-          id: transactionId,
-          status: TransactionStatus.FAILED,
-          expiry: expect.any(Date),
-        }),
       );
+      expect(whereParams.id).toBe(transactionId);
+      expect(whereParams.status).toBe(TransactionStatus.FAILED);
+      expect(whereParams.expiry).toBeInstanceOf(Date);
       expect(result).toBe(true);
     });
 
@@ -233,13 +297,16 @@ describe('ScheduledJobsService', () => {
       const result = await service['claimPendingTransactions']();
 
       expect(result).toEqual(mockTransactions);
-      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+      const whereCall = mockQueryBuilder.where.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      const [whereClause, whereParams] = whereCall;
+      expect(whereClause).toBe(
         'status = :status AND ("processingLockedAt" IS NULL OR "processingLockedAt" < :expiry)',
-        expect.objectContaining({
-          status: TransactionStatus.PENDING,
-          expiry: expect.any(Date),
-        }),
       );
+      expect(whereParams.status).toBe(TransactionStatus.PENDING);
+      expect(whereParams.expiry).toBeInstanceOf(Date);
     });
 
     it('should not claim a transaction with a recent lock', async () => {

--- a/src/scheduled-jobs/scheduler-registration.spec.ts
+++ b/src/scheduled-jobs/scheduler-registration.spec.ts
@@ -1,0 +1,180 @@
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ScheduleModule, SchedulerRegistry } from '@nestjs/schedule';
+import { ScheduledJobsService } from './scheduled-jobs.service';
+import { TransactionVerificationService } from '../transactions/services/transaction-verification.service';
+import { TransactionsService } from '../transactions/services/transaction.service';
+import { UsersService } from '../users/users.service';
+import { RateAlertsService } from '../rate-alerts/rate-alerts.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
+import { ExchangeRatesProviderClient } from '../exchange-rates/providers/exchange-rates.provider';
+import { ExchangeRatesCache } from '../exchange-rates/cache/exchange-rates.cache';
+import { CurrenciesService } from '../currencies/currencies.service';
+import { FeesService } from '../fees/fees.service';
+import { ReferralsService } from '../referrals/referrals.service';
+import { BeneficiariesService } from '../beneficiaries/beneficiaries.service';
+import { FirebaseService } from '../firebase/firebase.service';
+import { AuditLogsService } from '../audit-logs/audit-logs.service';
+import { AuditLogsRepository } from '../audit-logs/audit-logs.repository';
+import { StellarService } from '../blockchain/stellar/stellar.service';
+import { Transaction } from '../transactions/entities/transaction.entity';
+import { Notification } from '../notifications/entities/notification.entity';
+import { User } from '../users/user.entity';
+import { RateAlert } from '../rate-alerts/entities/rate-alert.entity';
+import { Currency } from '../currencies/currency.entity';
+import { FeeConfig } from '../fees/entities/fee-config.entity';
+import { FeeRecord } from '../fees/entities/fee-record.entity';
+import { Referral } from '../referrals/entities/referral.entity';
+import { Beneficiary } from '../beneficiaries/entities/beneficiary.entity';
+
+type ProviderWrapper = {
+  name: string;
+  isDependencyTreeStatic: () => boolean;
+};
+
+type ModuleEntry = {
+  providers: Map<unknown, ProviderWrapper>;
+};
+
+type ContainerLike = {
+  getModules: () => Map<unknown, ModuleEntry>;
+};
+
+describe('Scheduler registration', () => {
+  let moduleRef: TestingModule;
+
+  const repositoryMock = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    countBy: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const configServiceMock = {
+    get: jest.fn((key: string) => {
+      const values: Record<string, string> = {
+        EXCHANGE_RATES_PROVIDER_BASE_URL: 'https://api.exchangerate.host',
+        EXCHANGE_RATES_PROVIDER_TIMEOUT_MS: '5000',
+        EXCHANGE_RATES_CACHE_TTL_SECONDS: '600',
+        EXCHANGE_RATES_CACHE_MAX_SIZE: '1000',
+        REFERRAL_REWARD_AMOUNT: '0',
+        REFERRAL_REWARD_CURRENCY: 'USD',
+        JWT_SECRET: 'test-secret',
+        NODE_ENV: 'test',
+        JWT_EXPIRES_IN: '15m',
+      };
+
+      return values[key];
+    }),
+  };
+
+  const httpServiceMock = {
+    get: jest.fn(),
+  };
+
+  const auditLogsRepositoryMock = {
+    createAuditLog: jest.fn(),
+    findLogsWithPagination: jest.fn(),
+  };
+
+  const firebaseServiceMock = {
+    sendToTokens: jest.fn(),
+  };
+
+  const stellarServiceMock = {
+    verifyTransaction: jest.fn(),
+    getWalletBalances: jest.fn(),
+    createTransaction: jest.fn(),
+    signTransaction: jest.fn(),
+    submitTransaction: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    moduleRef = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [
+        ScheduledJobsService,
+        TransactionVerificationService,
+        TransactionsService,
+        UsersService,
+        RateAlertsService,
+        NotificationsService,
+        ExchangeRatesService,
+        ExchangeRatesProviderClient,
+        ExchangeRatesCache,
+        CurrenciesService,
+        FeesService,
+        ReferralsService,
+        BeneficiariesService,
+        AuditLogsService,
+        { provide: ConfigService, useValue: configServiceMock },
+        { provide: HttpService, useValue: httpServiceMock },
+        { provide: AuditLogsRepository, useValue: auditLogsRepositoryMock },
+        { provide: FirebaseService, useValue: firebaseServiceMock },
+        { provide: StellarService, useValue: stellarServiceMock },
+        { provide: getRepositoryToken(Transaction), useValue: repositoryMock },
+        { provide: getRepositoryToken(Notification), useValue: repositoryMock },
+        { provide: getRepositoryToken(User), useValue: repositoryMock },
+        { provide: getRepositoryToken(RateAlert), useValue: repositoryMock },
+        { provide: getRepositoryToken(Currency), useValue: repositoryMock },
+        { provide: getRepositoryToken(FeeConfig), useValue: repositoryMock },
+        { provide: getRepositoryToken(FeeRecord), useValue: repositoryMock },
+        { provide: getRepositoryToken(Referral), useValue: repositoryMock },
+        { provide: getRepositoryToken(Beneficiary), useValue: repositoryMock },
+      ],
+    }).compile();
+  });
+
+  afterEach(async () => {
+    await moduleRef.close();
+  });
+
+  it('keeps both cron providers in a static dependency tree', () => {
+    const container = (moduleRef as unknown as { container: ContainerLike })
+      .container;
+    const providers = Array.from(container.getModules().values()).flatMap(
+      (moduleEntry) => Array.from(moduleEntry.providers.values()),
+    );
+
+    const scheduledJobsWrapper = providers.find(
+      (wrapper) => wrapper.name === ScheduledJobsService.name,
+    );
+    const transactionVerificationWrapper = providers.find(
+      (wrapper) => wrapper.name === TransactionVerificationService.name,
+    );
+
+    expect(scheduledJobsWrapper?.isDependencyTreeStatic()).toBe(true);
+    expect(transactionVerificationWrapper?.isDependencyTreeStatic()).toBe(true);
+  });
+
+  it('registers cron jobs without scheduler non-static-provider warnings', async () => {
+    const warnSpy = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+
+    await moduleRef.init();
+
+    const registry = moduleRef.get(SchedulerRegistry);
+    expect(registry.getCronJobs().size).toBe(7);
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Cannot register cron job'),
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/transactions/services/transaction-verification.service.spec.ts
+++ b/src/transactions/services/transaction-verification.service.spec.ts
@@ -1,0 +1,39 @@
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { TransactionsService } from './transaction.service';
+import { TransactionVerificationService } from './transaction-verification.service';
+
+describe('TransactionVerificationService', () => {
+  let service: TransactionVerificationService;
+
+  const mockTransactionsService = {
+    getPendingTransactions: jest.fn(),
+    verifyTransaction: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionVerificationService,
+        {
+          provide: TransactionsService,
+          useValue: mockTransactionsService,
+        },
+      ],
+    }).compile();
+
+    service = moduleRef.get(TransactionVerificationService);
+  });
+
+  it('verifyPendingTransactions is directly callable without throwing', async () => {
+    mockTransactionsService.getPendingTransactions.mockResolvedValue([]);
+
+    await expect(service.verifyPendingTransactions()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #297

---

## What changed

- removed the child `ScheduleModule` import from `ScheduledJobsModule` so scheduler bootstrap stays at the application root
- added direct-call regression tests for all scheduled job handlers in `ScheduledJobsService`
- added a direct-call regression test for `TransactionVerificationService.verifyPendingTransactions()`
- added a Nest-level scheduler registration test that verifies both cron providers are static and that cron jobs register without `Cannot register cron job ... non static provider` warnings

## Why it changed

Production logs reported that scheduled cron jobs were not registering on Render because Nest saw them as non-static providers. This PR hardens the scheduler wiring and adds stronger regression coverage around the actual Nest registration path instead of relying only on source inspection.

## Impact

- protects scheduled background jobs from drifting into non-static provider registration failures
- preserves existing cron schedules and business logic
- gives maintainers a focused test suite for the Render scheduler issue

## Root cause

Nest emits the Render warning only when a cron provider's dependency tree is non-static. The stronger regression test added here checks that both cron providers remain static and that scheduler registration completes without the warning.

## Validation

- `pnpm test -- --runInBand src/scheduled-jobs/scheduler-registration.spec.ts src/scheduled-jobs/scheduled-jobs.module.spec.ts src/scheduled-jobs/scheduled-jobs.service.spec.ts src/transactions/services/transaction-verification.service.spec.ts src/app.module.spec.ts`
- `pnpm exec eslint src/scheduled-jobs/scheduler-registration.spec.ts`
- `pnpm exec eslint src/app.module.spec.ts src/scheduled-jobs/scheduled-jobs.module.ts src/scheduled-jobs/scheduled-jobs.module.spec.ts src/scheduled-jobs/scheduled-jobs.service.spec.ts src/transactions/services/transaction-verification.service.spec.ts`

## Not validated here

- actual Render deployment logs
- production screenshot from Render startup
