### PR TITLE
updated workflow scripts to use node24 and latest versions of workflo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -33,15 +36,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -92,7 +95,7 @@ jobs:
         run: npm run build
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always() # Uploads even if previous steps fail
         with:
           name: coverage-report-node-${{ matrix.node-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Branch, tag or commit SHA to deploy
+        description: "Branch, tag or commit SHA to deploy"
         required: false
         default: main
         type: string
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.sha }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run labeler
         uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          config-path: .github/labeler.yml
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -29,7 +29,7 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: scorecard-results
           path: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -63,7 +63,7 @@ jobs:
           - javascript-typescript
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3


### PR DESCRIPTION
closes #346 

## Summary

- Upgrade `actions/checkout`, `actions/setup-node`, `actions/cache`, and `actions/upload-artifact` from `v4` → `v5` across all workflow files ahead of GitHub's forced Node.js 24 migration on June 2, 2026
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to `ci.yml` workflow env to validate compatibility now
- Fix pre-existing unclosed string quote in `deploy.yml` (line 13)
- Fix pre-existing invalid input `config-path` → `configuration-path` in `labeler.yml` (renamed in `actions/labeler@v5`)

## Files Changed

- `.github/workflows/ci.yml` — `checkout`, `setup-node`, `cache`, `upload-artifact` upgraded; Node 24 opt-in env added
- `.github/workflows/e2e.yml` — `checkout`, `setup-node` upgraded
- `.github/workflows/security.yml` — `checkout` (×3), `setup-node` upgraded
- `.github/workflows/docker.yml` — `checkout` upgraded
- `.github/workflows/deploy.yml` — `checkout` upgraded; pre-existing YAML syntax error fixed
- `.github/workflows/labeler.yml` — `checkout` upgraded; pre-existing invalid input name fixed
- `.github/workflows/scorecard.yml` — `checkout`, `upload-artifact` upgraded
- `.github/workflows/rollback.yml` — no affected actions, no changes needed

## Test plan

- [ ] Confirm CI passes on this PR with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` active in `ci.yml`
- [ ] Verify no deprecation warnings appear in any workflow run after merge

Issue #346 
