### PR TITLE
feat(notifications): add notification preferences and unsubscribe sup…

### DIFF
--- a/src/migrations/1760000000000-CreateNotificationPreferences.ts
+++ b/src/migrations/1760000000000-CreateNotificationPreferences.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateNotificationPreferences1760000000000 implements MigrationInterface {
+  name = 'CreateNotificationPreferences1760000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable('users'))) {
+      return;
+    }
+
+    await queryRunner.query(`
+      CREATE TYPE "public"."notification_preferences_notificationtype_enum" AS ENUM(
+        'SYSTEM',
+        'PROJECT',
+        'TRANSACTION',
+        'OTP',
+        'MESSAGING',
+        'CONTRIBUTION',
+        'INVITATION',
+        'SWAP_COMPLETED',
+        'WALLET_UPDATED',
+        'TRANSACTION_FAILED',
+        'DEPOSIT_CONFIRMED',
+        'WITHDRAWAL_PROCESSED',
+        'REFERRAL_REWARDED'
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TYPE "public"."notification_preferences_digestmode_enum" AS ENUM(
+        'IMMEDIATE',
+        'DAILY',
+        'WEEKLY'
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE "notification_preferences" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "notificationType" "public"."notification_preferences_notificationtype_enum" NOT NULL,
+        "emailEnabled" boolean NOT NULL DEFAULT true,
+        "pushEnabled" boolean NOT NULL DEFAULT true,
+        "inAppEnabled" boolean NOT NULL DEFAULT true,
+        "digestMode" "public"."notification_preferences_digestmode_enum" NOT NULL DEFAULT 'IMMEDIATE',
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_notification_preferences_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_notification_preferences_user_type" UNIQUE ("userId", "notificationType"),
+        CONSTRAINT "FK_notification_preferences_user" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable('notification_preferences'))) {
+      return;
+    }
+
+    await queryRunner.query('DROP TABLE "notification_preferences"');
+    await queryRunner.query(
+      'DROP TYPE "public"."notification_preferences_digestmode_enum"',
+    );
+    await queryRunner.query(
+      'DROP TYPE "public"."notification_preferences_notificationtype_enum"',
+    );
+  }
+}

--- a/src/notifications/controllers/notification-preference.controller.ts
+++ b/src/notifications/controllers/notification-preference.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  CurrentUser,
+  CurrentUserPayload,
+} from '../../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import {
+  BulkUpdateNotificationPreferencesDto,
+  UnsubscribeTokenQueryDto,
+} from '../dto/notification-preference.dto';
+import { NotificationPreferenceService } from '../services/notification-preference.service';
+
+@ApiTags('Notification Preferences')
+@Controller('notifications')
+export class NotificationPreferenceController {
+  constructor(
+    private readonly preferenceService: NotificationPreferenceService,
+  ) {}
+
+  @Get('preferences')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get notification preferences for current user' })
+  findAll(@CurrentUser() user: CurrentUserPayload) {
+    return this.preferenceService.findAll(user.userId);
+  }
+
+  @Patch('preferences')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Bulk update notification preferences' })
+  updateMany(
+    @CurrentUser() user: CurrentUserPayload,
+    @Body() dto: BulkUpdateNotificationPreferencesDto,
+  ) {
+    return this.preferenceService.updateMany(user.userId, dto.preferences);
+  }
+
+  @Post('unsubscribe')
+  @ApiOperation({
+    summary: 'Unsubscribe from email notifications by signed token',
+  })
+  unsubscribe(@Query() query: UnsubscribeTokenQueryDto) {
+    return this.preferenceService.unsubscribe(query.token);
+  }
+}

--- a/src/notifications/dto/notification-preference.dto.ts
+++ b/src/notifications/dto/notification-preference.dto.ts
@@ -1,0 +1,44 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { NotificationType } from '../enum/notificationType.enum';
+import { NotificationDigestMode } from '../entities/notification-preference.entity';
+
+export class NotificationPreferenceUpdateDto {
+  @IsEnum(NotificationType)
+  notificationType: NotificationType;
+
+  @IsOptional()
+  @IsBoolean()
+  emailEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  pushEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  inAppEnabled?: boolean;
+
+  @IsOptional()
+  @IsEnum(NotificationDigestMode)
+  digestMode?: NotificationDigestMode;
+}
+
+export class BulkUpdateNotificationPreferencesDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => NotificationPreferenceUpdateDto)
+  preferences: NotificationPreferenceUpdateDto[];
+}
+
+export class UnsubscribeTokenQueryDto {
+  @IsString()
+  token: string;
+}

--- a/src/notifications/entities/notification-preference.entity.ts
+++ b/src/notifications/entities/notification-preference.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/user.entity';
+import { NotificationType } from '../enum/notificationType.enum';
+
+export enum NotificationDigestMode {
+  IMMEDIATE = 'IMMEDIATE',
+  DAILY = 'DAILY',
+  WEEKLY = 'WEEKLY',
+}
+
+@Index(['userId', 'notificationType'], { unique: true })
+@Entity('notification_preferences')
+export class NotificationPreference {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({
+    type: 'enum',
+    enum: NotificationType,
+  })
+  notificationType: NotificationType;
+
+  @Column({ type: 'boolean', default: true })
+  emailEnabled: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  pushEnabled: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  inAppEnabled: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: NotificationDigestMode,
+    default: NotificationDigestMode.IMMEDIATE,
+  })
+  digestMode: NotificationDigestMode;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -3,11 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
 import { Notification } from './entities/notification.entity';
+import { NotificationPreference } from './entities/notification-preference.entity';
+import { NotificationPreferenceService } from './services/notification-preference.service';
+import { NotificationPreferenceController } from './controllers/notification-preference.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notification])],
-  controllers: [NotificationsController],
-  providers: [NotificationsService],
-  exports: [NotificationsService],
+  imports: [TypeOrmModule.forFeature([Notification, NotificationPreference])],
+  controllers: [NotificationsController, NotificationPreferenceController],
+  providers: [NotificationsService, NotificationPreferenceService],
+  exports: [NotificationsService, NotificationPreferenceService],
 })
 export class NotificationsModule {}

--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -8,6 +8,8 @@ import {
   NotificationStatus,
 } from './entities/notification.entity';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { NotificationPreferenceService } from './services/notification-preference.service';
+import { NotificationDigestMode } from './entities/notification-preference.entity';
 
 describe('NotificationsService', () => {
   let service: NotificationsService;
@@ -40,6 +42,12 @@ describe('NotificationsService', () => {
     createQueryBuilder: jest.fn(),
   } as unknown as jest.Mocked<Repository<Notification>>;
 
+  const mockPreferenceService = {
+    getPreference: jest.fn(),
+    isChannelEnabled: jest.fn(),
+    generateUnsubscribeToken: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -47,6 +55,10 @@ describe('NotificationsService', () => {
         {
           provide: getRepositoryToken(Notification),
           useValue: mockRepository,
+        },
+        {
+          provide: NotificationPreferenceService,
+          useValue: mockPreferenceService,
         },
       ],
     }).compile();
@@ -61,6 +73,10 @@ describe('NotificationsService', () => {
 
   describe('create', () => {
     it('should create a notification', async () => {
+      mockPreferenceService.getPreference.mockResolvedValue({
+        digestMode: NotificationDigestMode.IMMEDIATE,
+      });
+      mockPreferenceService.isChannelEnabled.mockResolvedValue(true);
       repository.create.mockReturnValue(mockNotification);
       repository.save.mockResolvedValue(mockNotification);
 
@@ -71,10 +87,32 @@ describe('NotificationsService', () => {
         message: 'Test message',
       });
 
-      expect(result.title).toBe('Test Notification');
+      expect(result).toMatchObject({ title: 'Test Notification' });
+    });
+
+    it('should return null when in-app channel is disabled', async () => {
+      mockPreferenceService.getPreference.mockResolvedValue({
+        digestMode: NotificationDigestMode.IMMEDIATE,
+      });
+      mockPreferenceService.isChannelEnabled.mockResolvedValue(false);
+
+      const result = await service.create({
+        userId: mockNotification.userId,
+        type: NotificationType.SYSTEM,
+        title: 'Test',
+        message: 'Test message',
+      });
+
+      expect(result).toBeNull();
+      expect(repository.create).not.toHaveBeenCalled();
+      expect(repository.save).not.toHaveBeenCalled();
     });
 
     it('should throw BadRequestException on error', async () => {
+      mockPreferenceService.getPreference.mockResolvedValue({
+        digestMode: NotificationDigestMode.IMMEDIATE,
+      });
+      mockPreferenceService.isChannelEnabled.mockResolvedValue(true);
       repository.create.mockImplementation(() => {
         throw new Error();
       });

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -17,6 +17,8 @@ import {
   PaginatedNotificationResponse,
 } from './dto/notification-response.dto';
 import { InjectRepository } from '@nestjs/typeorm';
+import { NotificationPreferenceService } from './services/notification-preference.service';
+import { NotificationDigestMode } from './entities/notification-preference.entity';
 
 @Injectable()
 export class NotificationsService {
@@ -25,14 +27,39 @@ export class NotificationsService {
   constructor(
     @InjectRepository(Notification)
     private notificationsRepository: Repository<Notification>,
+    private readonly preferenceService: NotificationPreferenceService,
   ) {}
 
   async create(
     createNotificationDto: CreateNotificationDto,
-  ): Promise<NotificationResponseDto> {
+  ): Promise<NotificationResponseDto | null> {
     try {
+      const preference = await this.preferenceService.getPreference(
+        createNotificationDto.userId,
+        createNotificationDto.type,
+      );
+
+      if (
+        !(await this.preferenceService.isChannelEnabled(
+          createNotificationDto.userId,
+          createNotificationDto.type,
+          'inApp',
+        ))
+      ) {
+        return null;
+      }
+
       const notification = this.notificationsRepository.create(
-        createNotificationDto,
+        preference.digestMode === NotificationDigestMode.IMMEDIATE
+          ? createNotificationDto
+          : {
+              ...createNotificationDto,
+              metadata: {
+                ...(createNotificationDto.metadata ?? {}),
+                digestMode: preference.digestMode,
+                digestPending: true,
+              },
+            },
       );
       const saved = await this.notificationsRepository.save(notification);
       return this.mapToResponseDto(saved);
@@ -202,6 +229,18 @@ export class NotificationsService {
   async deleteAllByUser(userId: string): Promise<{ deleted: number }> {
     const result = await this.notificationsRepository.delete({ userId });
     return { deleted: result.affected || 0 };
+  }
+
+  async canSendChannel(
+    userId: string,
+    type: NotificationType,
+    channel: 'email' | 'push' | 'inApp',
+  ): Promise<boolean> {
+    return this.preferenceService.isChannelEnabled(userId, type, channel);
+  }
+
+  generateUnsubscribeToken(userId: string, type: NotificationType): string {
+    return this.preferenceService.generateUnsubscribeToken(userId, type);
   }
 
   async findByType(

--- a/src/notifications/services/notification-preference.service.ts
+++ b/src/notifications/services/notification-preference.service.ts
@@ -1,0 +1,214 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { Repository } from 'typeorm';
+import { NotificationType } from '../enum/notificationType.enum';
+import {
+  NotificationDigestMode,
+  NotificationPreference,
+} from '../entities/notification-preference.entity';
+import { NotificationPreferenceUpdateDto } from '../dto/notification-preference.dto';
+
+const NON_DISABLEABLE_TYPES = new Set<NotificationType>([
+  NotificationType.OTP,
+  NotificationType.TRANSACTION,
+  NotificationType.TRANSACTION_FAILED,
+  NotificationType.DEPOSIT_CONFIRMED,
+  NotificationType.WITHDRAWAL_PROCESSED,
+  NotificationType.SWAP_COMPLETED,
+]);
+
+@Injectable()
+export class NotificationPreferenceService {
+  constructor(
+    @InjectRepository(NotificationPreference)
+    private readonly preferenceRepository: Repository<NotificationPreference>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async createDefaults(userId: string): Promise<void> {
+    const preferences = Object.values(NotificationType).map(
+      (notificationType) =>
+        this.preferenceRepository.create({
+          userId,
+          notificationType,
+          emailEnabled: true,
+          pushEnabled: true,
+          inAppEnabled: true,
+          digestMode: NotificationDigestMode.IMMEDIATE,
+        }),
+    );
+
+    await this.preferenceRepository
+      .createQueryBuilder()
+      .insert()
+      .into(NotificationPreference)
+      .values(preferences)
+      .orIgnore()
+      .execute();
+  }
+
+  async findAll(userId: string): Promise<NotificationPreference[]> {
+    await this.createDefaults(userId);
+    return this.preferenceRepository.find({
+      where: { userId },
+      order: { notificationType: 'ASC' },
+    });
+  }
+
+  async updateMany(
+    userId: string,
+    updates: NotificationPreferenceUpdateDto[],
+  ): Promise<NotificationPreference[]> {
+    if (!updates?.length) {
+      throw new BadRequestException('At least one preference is required');
+    }
+
+    await this.createDefaults(userId);
+
+    for (const update of updates) {
+      const guarded = this.applyMandatoryChannels(update);
+      await this.preferenceRepository.update(
+        { userId, notificationType: update.notificationType },
+        guarded,
+      );
+    }
+
+    return this.findAll(userId);
+  }
+
+  async getPreference(
+    userId: string,
+    notificationType: NotificationType,
+  ): Promise<NotificationPreference> {
+    await this.createDefaults(userId);
+    const preference = await this.preferenceRepository.findOne({
+      where: { userId, notificationType },
+    });
+
+    if (!preference) {
+      throw new BadRequestException('Notification preference was not created');
+    }
+
+    return preference;
+  }
+
+  async isChannelEnabled(
+    userId: string,
+    notificationType: NotificationType,
+    channel: 'email' | 'push' | 'inApp',
+  ): Promise<boolean> {
+    if (NON_DISABLEABLE_TYPES.has(notificationType)) {
+      return true;
+    }
+
+    const preference = await this.getPreference(userId, notificationType);
+
+    if (channel === 'email') return preference.emailEnabled;
+    if (channel === 'push') return preference.pushEnabled;
+    return preference.inAppEnabled;
+  }
+
+  async unsubscribe(token: string): Promise<{ message: string }> {
+    const payload = this.verifyToken(token);
+    await this.createDefaults(payload.userId);
+
+    if (NON_DISABLEABLE_TYPES.has(payload.notificationType)) {
+      return { message: 'This notification type cannot be unsubscribed' };
+    }
+
+    await this.preferenceRepository.update(
+      {
+        userId: payload.userId,
+        notificationType: payload.notificationType,
+      },
+      {
+        emailEnabled: false,
+        digestMode: NotificationDigestMode.IMMEDIATE,
+      },
+    );
+
+    return { message: 'You have been unsubscribed from these emails' };
+  }
+
+  generateUnsubscribeToken(
+    userId: string,
+    notificationType: NotificationType,
+  ): string {
+    const body = `${userId}:${notificationType}`;
+    const signature = this.sign(body);
+    return Buffer.from(`${body}:${signature}`).toString('base64url');
+  }
+
+  private applyMandatoryChannels(
+    update: NotificationPreferenceUpdateDto,
+  ): Partial<NotificationPreference> {
+    const guarded: Partial<NotificationPreference> = {
+      emailEnabled: update.emailEnabled,
+      pushEnabled: update.pushEnabled,
+      inAppEnabled: update.inAppEnabled,
+      digestMode: update.digestMode,
+    };
+
+    if (NON_DISABLEABLE_TYPES.has(update.notificationType)) {
+      guarded.emailEnabled = true;
+      guarded.pushEnabled = true;
+      guarded.inAppEnabled = true;
+      guarded.digestMode = NotificationDigestMode.IMMEDIATE;
+    }
+
+    return guarded;
+  }
+
+  private verifyToken(token: string): {
+    userId: string;
+    notificationType: NotificationType;
+  } {
+    let decoded: string;
+    try {
+      decoded = Buffer.from(token, 'base64url').toString('utf8');
+    } catch {
+      throw new ForbiddenException('Invalid unsubscribe token');
+    }
+
+    const parts = decoded.split(':');
+    if (parts.length !== 3) {
+      throw new ForbiddenException('Invalid unsubscribe token');
+    }
+
+    const [userId, notificationType, signature] = parts;
+    if (!Object.values(NotificationType).includes(notificationType as any)) {
+      throw new ForbiddenException('Invalid unsubscribe token');
+    }
+
+    const expected = this.sign(`${userId}:${notificationType}`);
+    const expectedBuffer = Buffer.from(expected);
+    const actualBuffer = Buffer.from(signature);
+
+    if (
+      expectedBuffer.length !== actualBuffer.length ||
+      !timingSafeEqual(expectedBuffer, actualBuffer)
+    ) {
+      throw new ForbiddenException('Invalid unsubscribe token');
+    }
+
+    return {
+      userId,
+      notificationType: notificationType as NotificationType,
+    };
+  }
+
+  private sign(payload: string): string {
+    const secret = this.configService.get<string>('JWT_SECRET');
+    if (!secret) {
+      throw new BadRequestException('JWT_SECRET is required');
+    }
+
+    return createHmac('sha256', secret).update(payload).digest('hex');
+  }
+}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -7,6 +7,7 @@ import { User, UserRole, UserPlan } from './user.entity';
 import { RateLimitConfig } from './rate-limit-config.entity';
 import { StellarService } from '../blockchain/stellar/stellar.service';
 import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
+import { NotificationPreferenceService } from '../notifications/services/notification-preference.service';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -80,6 +81,12 @@ describe('UsersService', () => {
             getRecord: jest.fn(),
             addRecord: jest.fn(),
             increment: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationPreferenceService,
+          useValue: {
+            createDefaults: jest.fn(),
           },
         },
       ],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -20,6 +20,7 @@ import { WalletBalanceResult } from '../blockchain/stellar/stellar.types';
 import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
 import { RateLimitConfig } from './rate-limit-config.entity';
 import { ThrottlerStorageService } from '@nestjs/throttler';
+import { NotificationPreferenceService } from '../notifications/services/notification-preference.service';
 
 interface WalletBalancesCacheEntry {
   expiresAt: number;
@@ -43,6 +44,7 @@ export class UsersService {
     private readonly stellarService: StellarService,
     private readonly exchangeRatesService: ExchangeRatesService,
     private readonly throttlerStorageService: ThrottlerStorageService,
+    private readonly notificationPreferenceService: NotificationPreferenceService,
   ) {}
 
   async findByEmail(email: string): Promise<User | null> {
@@ -126,6 +128,7 @@ export class UsersService {
     });
 
     const savedUser = await this.userRepository.save(user);
+    await this.notificationPreferenceService.createDefaults(savedUser.id);
 
     const {
       password: _,


### PR DESCRIPTION
## Description
- add notification preferences persisted per user and notification type
- - add endpoints to fetch and bulk update preferences
- - add signed unsubscribe flow for email notifications
- - enforce mandatory channels for critical notification types
- - initialize defaults when a user is created
## Related Issue
Closes #307 
## Type of Change
- [x] New feature
- [ ] - [x] Test
## Testing Steps
- npm test -- --runInBand
- - result: 35 suites passed, 203 tests passed
## Checklist
- [x] code follows project standards
- [ ] - [x] self-review completed
- [ ] - [x] tests pass locally
- [ ] - [x] documentation update not required