### PR TITLE
feat(transactions): enforce KYC tier transaction limits

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Post,
   Patch,
   Param,
   Body,
@@ -30,8 +31,13 @@ import { UpdateUserPlanDto } from './dto/update-user-plan.dto';
 import { AdminTransactionQueryDto } from './dto/admin-transaction-query.dto';
 import { MetricsQueryDto } from './dto/metrics-query.dto';
 import { OverrideTransactionDto } from './dto/override-transaction.dto';
+import {
+  PatchTransactionLimitDto,
+  UpsertTransactionLimitDto,
+} from './dto/transaction-limit.dto';
 import { Response } from 'express';
 import { join } from 'path';
+import { UserKycTier } from '../users/user.entity';
 
 @ApiTags('Admin')
 @ApiBearerAuth()
@@ -255,6 +261,27 @@ export class AdminController {
       overrideDto,
       admin.userId,
     );
+  }
+
+  @Get('transaction-limits')
+  @ApiOperation({ summary: 'List KYC tier transaction limits (Admin only)' })
+  async listTransactionLimits() {
+    return this.adminService.listTransactionLimits();
+  }
+
+  @Post('transaction-limits')
+  @ApiOperation({ summary: 'Create or replace KYC tier transaction limit' })
+  async upsertTransactionLimit(@Body() dto: UpsertTransactionLimitDto) {
+    return this.adminService.upsertTransactionLimit(dto);
+  }
+
+  @Patch('transaction-limits/:tier')
+  @ApiOperation({ summary: 'Update KYC tier transaction limit' })
+  async patchTransactionLimit(
+    @Param('tier') tier: UserKycTier,
+    @Body() dto: PatchTransactionLimitDto,
+  ) {
+    return this.adminService.patchTransactionLimit(tier, dto);
   }
 
   @Get('kyc-file/:userId/:version/:filename')

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -7,12 +7,14 @@ import { Transaction } from '../transactions/entities/transaction.entity';
 import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 import { ReportsModule } from './reports/reports.module';
 import { DataRequest } from '../users/entities/data-request.entity';
+import { TransactionLimitsModule } from '../transactions/transaction-limits.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, Transaction, DataRequest]),
     AuditLogsModule,
     ReportsModule,
+    TransactionLimitsModule,
   ],
   controllers: [AdminController],
   providers: [AdminService],

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@nestjs/common';
 import { UserQueryDto } from './dto/user-query.dto';
 import { OverrideTransactionDto } from './dto/override-transaction.dto';
+import { TransactionLimitService } from '../transactions/services/transaction-limit.service';
 
 describe('AdminService', () => {
   let service: AdminService;
@@ -125,6 +126,13 @@ describe('AdminService', () => {
           useValue: {
             logAuthEvent: jest.fn(),
             logTransactionEvent: jest.fn(),
+          },
+        },
+        {
+          provide: TransactionLimitService,
+          useValue: {
+            listLimits: jest.fn(),
+            upsertLimit: jest.fn(),
           },
         },
       ],

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -43,6 +43,12 @@ import {
   DataRequestStatus,
 } from '../users/entities/data-request.entity';
 import { UpdateUserPlanDto } from './dto/update-user-plan.dto';
+import { TransactionLimitService } from '../transactions/services/transaction-limit.service';
+import { UserKycTier } from '../users/user.entity';
+import {
+  PatchTransactionLimitDto,
+  UpsertTransactionLimitDto,
+} from './dto/transaction-limit.dto';
 
 @Injectable()
 export class AdminService {
@@ -56,7 +62,28 @@ export class AdminService {
     @InjectRepository(DataRequest)
     private readonly dataRequestRepository: Repository<DataRequest>,
     private readonly auditLogsService: AuditLogsService,
+    private readonly transactionLimitService: TransactionLimitService,
   ) {}
+
+  async listTransactionLimits() {
+    return this.transactionLimitService.listLimits();
+  }
+
+  async upsertTransactionLimit(dto: UpsertTransactionLimitDto) {
+    return this.transactionLimitService.upsertLimit(dto.tier, {
+      dailyLimitUsd: dto.dailyLimitUsd,
+      monthlyLimitUsd: dto.monthlyLimitUsd,
+      singleTxLimitUsd: dto.singleTxLimitUsd,
+    });
+  }
+
+  async patchTransactionLimit(tier: UserKycTier, dto: PatchTransactionLimitDto) {
+    return this.transactionLimitService.upsertLimit(tier, {
+      dailyLimitUsd: dto.dailyLimitUsd,
+      monthlyLimitUsd: dto.monthlyLimitUsd,
+      singleTxLimitUsd: dto.singleTxLimitUsd,
+    });
+  }
 
   async getPlatformMetrics(
     query: MetricsQueryDto = {},

--- a/src/admin/dto/transaction-limit.dto.ts
+++ b/src/admin/dto/transaction-limit.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, Min } from 'class-validator';
+import { UserKycTier } from '../../users/user.entity';
+
+export class UpsertTransactionLimitDto {
+  @ApiProperty({ enum: UserKycTier })
+  @IsEnum(UserKycTier)
+  tier: UserKycTier;
+
+  @ApiProperty({ example: 1000 })
+  @IsNumber()
+  @Min(0)
+  dailyLimitUsd: number;
+
+  @ApiProperty({ example: 15000 })
+  @IsNumber()
+  @Min(0)
+  monthlyLimitUsd: number;
+
+  @ApiProperty({ example: 1000 })
+  @IsNumber()
+  @Min(0)
+  singleTxLimitUsd: number;
+}
+
+export class PatchTransactionLimitDto {
+  @ApiProperty({ example: 1000 })
+  @IsNumber()
+  @Min(0)
+  dailyLimitUsd: number;
+
+  @ApiProperty({ example: 15000 })
+  @IsNumber()
+  @Min(0)
+  monthlyLimitUsd: number;
+
+  @ApiProperty({ example: 1000 })
+  @IsNumber()
+  @Min(0)
+  singleTxLimitUsd: number;
+}

--- a/src/kyc/kyc.service.ts
+++ b/src/kyc/kyc.service.ts
@@ -16,6 +16,7 @@ import { Notification } from '../notifications/entities/notification.entity';
 import { NotificationType } from '../notifications/entities/notification.entity';
 import { NotificationStatus } from '../notifications/entities/notification.entity';
 import { FirebaseService } from '../firebase/firebase.service';
+import { UserKycTier } from '../users/user.entity';
 
 @Injectable()
 export class KycService {
@@ -179,10 +180,17 @@ export class KycService {
 
       if (decision === KycStatus.APPROVED) {
         kyc.status = KycStatus.APPROVED;
-        kyc.tier = 2;
+        const tier = this.resolveUserKycTier(kyc);
+        kyc.tier =
+          tier === UserKycTier.BASIC
+            ? KycTier.TIER_1
+            : tier === UserKycTier.UNVERIFIED
+              ? KycTier.TIER_0
+              : KycTier.TIER_2;
         kyc.reviewedAt = new Date();
 
         user.isVerified = true;
+        user.kycTier = tier;
 
         notificationPayload = {
           userId: user.id,
@@ -195,7 +203,7 @@ export class KycService {
           metadata: {
             entity: 'KYC',
             kycStatus: 'approved',
-            tier: 2,
+            tier,
           },
         };
       } else {
@@ -204,6 +212,7 @@ export class KycService {
         kyc.reviewedAt = new Date();
 
         user.isVerified = false;
+  user.kycTier = UserKycTier.UNVERIFIED;
 
         notificationPayload = {
           userId: user.id,
@@ -244,5 +253,22 @@ export class KycService {
         message: `KYC ${decision} successfully`,
       };
     });
+  }
+
+  private resolveUserKycTier(kyc: KycRecord): UserKycTier {
+    const hasId = !!kyc.documentFrontUrl;
+    const hasSelfie = !!kyc.selfieUrl;
+    const hasProofOfAddress = !!kyc.documentBackUrl;
+
+    if (hasId && hasSelfie && hasProofOfAddress) {
+      return UserKycTier.FULL;
+    }
+    if (hasId && hasSelfie) {
+      return UserKycTier.ENHANCED;
+    }
+    if (hasId) {
+      return UserKycTier.BASIC;
+    }
+    return UserKycTier.UNVERIFIED;
   }
 }

--- a/src/migrations/1761000000000-AddKycTierAndTransactionLimits.ts
+++ b/src/migrations/1761000000000-AddKycTierAndTransactionLimits.ts
@@ -15,10 +15,12 @@ export class AddKycTierAndTransactionLimits1761000000000
       )
     `);
 
-    await queryRunner.query(`
-      ALTER TABLE "users"
-      ADD COLUMN "kycTier" "public"."users_kyctier_enum" NOT NULL DEFAULT 'UNVERIFIED'
-    `);
+    if (await queryRunner.hasTable('users')) {
+      await queryRunner.query(`
+        ALTER TABLE "users"
+        ADD COLUMN "kycTier" "public"."users_kyctier_enum" NOT NULL DEFAULT 'UNVERIFIED'
+      `);
+    }
 
     await queryRunner.query(`
       CREATE TABLE "transaction_limits" (
@@ -44,8 +46,10 @@ export class AddKycTierAndTransactionLimits1761000000000
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('DROP TABLE "transaction_limits"');
-    await queryRunner.query('ALTER TABLE "users" DROP COLUMN "kycTier"');
-    await queryRunner.query('DROP TYPE "public"."users_kyctier_enum"');
+    await queryRunner.query('DROP TABLE IF EXISTS "transaction_limits"');
+    if (await queryRunner.hasTable('users')) {
+      await queryRunner.query('ALTER TABLE "users" DROP COLUMN IF EXISTS "kycTier"');
+    }
+    await queryRunner.query('DROP TYPE IF EXISTS "public"."users_kyctier_enum"');
   }
 }

--- a/src/migrations/1761000000000-AddKycTierAndTransactionLimits.ts
+++ b/src/migrations/1761000000000-AddKycTierAndTransactionLimits.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddKycTierAndTransactionLimits1761000000000
+  implements MigrationInterface
+{
+  name = 'AddKycTierAndTransactionLimits1761000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "public"."users_kyctier_enum" AS ENUM (
+        'UNVERIFIED',
+        'BASIC',
+        'ENHANCED',
+        'FULL'
+      )
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD COLUMN "kycTier" "public"."users_kyctier_enum" NOT NULL DEFAULT 'UNVERIFIED'
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "transaction_limits" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "tier" "public"."users_kyctier_enum" NOT NULL,
+        "dailyLimitUsd" numeric(20,8) NOT NULL,
+        "monthlyLimitUsd" numeric(20,8) NOT NULL,
+        "singleTxLimitUsd" numeric(20,8) NOT NULL,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_transaction_limits_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_transaction_limits_tier" UNIQUE ("tier")
+      )
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO "transaction_limits" ("tier", "dailyLimitUsd", "monthlyLimitUsd", "singleTxLimitUsd") VALUES
+      ('UNVERIFIED', 100, 1000, 100),
+      ('BASIC', 1000, 15000, 1000),
+      ('ENHANCED', 10000, 150000, 10000),
+      ('FULL', 50000, 500000, 50000)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE "transaction_limits"');
+    await queryRunner.query('ALTER TABLE "users" DROP COLUMN "kycTier"');
+    await queryRunner.query('DROP TYPE "public"."users_kyctier_enum"');
+  }
+}

--- a/src/transactions/entities/transaction-limit.entity.ts
+++ b/src/transactions/entities/transaction-limit.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { UserKycTier } from '../../users/user.entity';
+
+@Entity('transaction_limits')
+export class TransactionLimit {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({
+    type: 'enum',
+    enum: UserKycTier,
+    unique: true,
+  })
+  tier: UserKycTier;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8 })
+  dailyLimitUsd: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8 })
+  monthlyLimitUsd: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8 })
+  singleTxLimitUsd: string;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/src/transactions/services/transaction-limit.service.ts
+++ b/src/transactions/services/transaction-limit.service.ts
@@ -1,0 +1,267 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ExchangeRatesService } from '../../exchange-rates/exchange-rates.service';
+import { User, UserKycTier } from '../../users/user.entity';
+import {
+  Transaction,
+  TransactionStatus,
+} from '../entities/transaction.entity';
+import { TransactionLimit } from '../entities/transaction-limit.entity';
+
+interface UsageSummary {
+  todayUsd: number;
+  monthUsd: number;
+}
+
+@Injectable()
+export class TransactionLimitService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Transaction)
+    private readonly transactionRepository: Repository<Transaction>,
+    @InjectRepository(TransactionLimit)
+    private readonly transactionLimitRepository: Repository<TransactionLimit>,
+    private readonly exchangeRatesService: ExchangeRatesService,
+  ) {}
+
+  async ensureDefaultLimits(): Promise<void> {
+    const defaults: Array<{
+      tier: UserKycTier;
+      dailyLimitUsd: string;
+      monthlyLimitUsd: string;
+      singleTxLimitUsd: string;
+    }> = [
+      {
+        tier: UserKycTier.UNVERIFIED,
+        dailyLimitUsd: '100',
+        monthlyLimitUsd: '1000',
+        singleTxLimitUsd: '100',
+      },
+      {
+        tier: UserKycTier.BASIC,
+        dailyLimitUsd: '1000',
+        monthlyLimitUsd: '15000',
+        singleTxLimitUsd: '1000',
+      },
+      {
+        tier: UserKycTier.ENHANCED,
+        dailyLimitUsd: '10000',
+        monthlyLimitUsd: '150000',
+        singleTxLimitUsd: '10000',
+      },
+      {
+        tier: UserKycTier.FULL,
+        dailyLimitUsd: '50000',
+        monthlyLimitUsd: '500000',
+        singleTxLimitUsd: '50000',
+      },
+    ];
+
+    for (const row of defaults) {
+      const existing = await this.transactionLimitRepository.findOne({
+        where: { tier: row.tier },
+      });
+      if (!existing) {
+        await this.transactionLimitRepository.save(
+          this.transactionLimitRepository.create(row),
+        );
+      }
+    }
+  }
+
+  async listLimits(): Promise<TransactionLimit[]> {
+    await this.ensureDefaultLimits();
+    return this.transactionLimitRepository.find({ order: { tier: 'ASC' } });
+  }
+
+  async upsertLimit(
+    tier: UserKycTier,
+    data: {
+      dailyLimitUsd: number;
+      monthlyLimitUsd: number;
+      singleTxLimitUsd: number;
+    },
+  ): Promise<TransactionLimit> {
+    if (data.dailyLimitUsd < 0 || data.monthlyLimitUsd < 0 || data.singleTxLimitUsd < 0) {
+      throw new BadRequestException('Limit values must be greater than or equal to 0');
+    }
+
+    await this.ensureDefaultLimits();
+
+    const existing = await this.transactionLimitRepository.findOne({ where: { tier } });
+    if (!existing) {
+      return this.transactionLimitRepository.save(
+        this.transactionLimitRepository.create({
+          tier,
+          dailyLimitUsd: data.dailyLimitUsd.toFixed(8),
+          monthlyLimitUsd: data.monthlyLimitUsd.toFixed(8),
+          singleTxLimitUsd: data.singleTxLimitUsd.toFixed(8),
+        }),
+      );
+    }
+
+    existing.dailyLimitUsd = data.dailyLimitUsd.toFixed(8);
+    existing.monthlyLimitUsd = data.monthlyLimitUsd.toFixed(8);
+    existing.singleTxLimitUsd = data.singleTxLimitUsd.toFixed(8);
+    return this.transactionLimitRepository.save(existing);
+  }
+
+  async check(
+    userId: string,
+    amount: number,
+    currency: string,
+  ): Promise<void> {
+    const status = await this.getUserLimitStatus(userId);
+    const amountUsd = await this.convertToUsd(currency, amount);
+
+    const singleTxLimit = Number(status.limits.singleTxLimitUsd);
+    if (amountUsd > singleTxLimit) {
+      throw new UnprocessableEntityException({
+        code: 'SINGLE_TX_LIMIT_EXCEEDED',
+        message: 'Single transaction limit exceeded for your KYC tier',
+        remainingAllowance: Math.max(singleTxLimit, 0),
+      });
+    }
+
+    const dailyLimit = Number(status.limits.dailyLimitUsd);
+    const dailyRemaining = Math.max(dailyLimit - status.usage.todayUsd, 0);
+    if (amountUsd > dailyRemaining) {
+      throw new UnprocessableEntityException({
+        code: 'DAILY_LIMIT_EXCEEDED',
+        message: 'Daily transaction limit exceeded for your KYC tier',
+        remainingAllowance: Number(dailyRemaining.toFixed(8)),
+      });
+    }
+
+    const monthlyLimit = Number(status.limits.monthlyLimitUsd);
+    const monthlyRemaining = Math.max(monthlyLimit - status.usage.monthUsd, 0);
+    if (amountUsd > monthlyRemaining) {
+      throw new UnprocessableEntityException({
+        code: 'MONTHLY_LIMIT_EXCEEDED',
+        message: 'Monthly transaction limit exceeded for your KYC tier',
+        remainingAllowance: Number(monthlyRemaining.toFixed(8)),
+      });
+    }
+  }
+
+  async getUserLimitStatus(userId: string): Promise<{
+    tier: UserKycTier;
+    limits: {
+      dailyLimitUsd: number;
+      monthlyLimitUsd: number;
+      singleTxLimitUsd: number;
+    };
+    usage: UsageSummary;
+    remaining: {
+      dailyUsd: number;
+      monthlyUsd: number;
+    };
+  }> {
+    await this.ensureDefaultLimits();
+
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const limit = await this.transactionLimitRepository.findOne({
+      where: { tier: user.kycTier },
+    });
+
+    if (!limit) {
+      throw new NotFoundException('Transaction limit configuration not found');
+    }
+
+    const usage = await this.getUsageInUsd(userId);
+    const dailyLimit = Number(limit.dailyLimitUsd);
+    const monthlyLimit = Number(limit.monthlyLimitUsd);
+
+    return {
+      tier: user.kycTier,
+      limits: {
+        dailyLimitUsd: dailyLimit,
+        monthlyLimitUsd: monthlyLimit,
+        singleTxLimitUsd: Number(limit.singleTxLimitUsd),
+      },
+      usage,
+      remaining: {
+        dailyUsd: Number(Math.max(dailyLimit - usage.todayUsd, 0).toFixed(8)),
+        monthlyUsd: Number(
+          Math.max(monthlyLimit - usage.monthUsd, 0).toFixed(8),
+        ),
+      },
+    };
+  }
+
+  private async getUsageInUsd(userId: string): Promise<UsageSummary> {
+    const now = new Date();
+    const dayStart = new Date(now);
+    dayStart.setUTCHours(0, 0, 0, 0);
+
+    const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+    const [dayRows, monthRows] = await Promise.all([
+      this.transactionRepository
+        .createQueryBuilder('t')
+        .select('t.currency', 'currency')
+        .addSelect('SUM(CAST(t.amount AS DECIMAL))', 'total')
+        .where('t.userId = :userId', { userId })
+        .andWhere('t.status IN (:...statuses)', {
+          statuses: [TransactionStatus.PENDING, TransactionStatus.SUCCESS],
+        })
+        .andWhere('t.createdAt >= :dayStart', { dayStart })
+        .groupBy('t.currency')
+        .getRawMany<{ currency: string; total: string }>(),
+      this.transactionRepository
+        .createQueryBuilder('t')
+        .select('t.currency', 'currency')
+        .addSelect('SUM(CAST(t.amount AS DECIMAL))', 'total')
+        .where('t.userId = :userId', { userId })
+        .andWhere('t.status IN (:...statuses)', {
+          statuses: [TransactionStatus.PENDING, TransactionStatus.SUCCESS],
+        })
+        .andWhere('t.createdAt >= :monthStart', { monthStart })
+        .groupBy('t.currency')
+        .getRawMany<{ currency: string; total: string }>(),
+    ]);
+
+    const todayUsd = await this.convertRowsToUsd(dayRows);
+    const monthUsd = await this.convertRowsToUsd(monthRows);
+
+    return {
+      todayUsd: Number(todayUsd.toFixed(8)),
+      monthUsd: Number(monthUsd.toFixed(8)),
+    };
+  }
+
+  private async convertRowsToUsd(
+    rows: Array<{ currency: string; total: string }>,
+  ): Promise<number> {
+    let sumUsd = 0;
+    for (const row of rows) {
+      const amount = Number(row.total ?? 0);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        continue;
+      }
+      sumUsd += await this.convertToUsd(row.currency, amount);
+    }
+    return sumUsd;
+  }
+
+  private async convertToUsd(currency: string, amount: number): Promise<number> {
+    const normalizedCurrency = currency.toUpperCase();
+    if (normalizedCurrency === 'USD') {
+      return amount;
+    }
+
+    const rate = await this.exchangeRatesService.getRate(normalizedCurrency, 'USD');
+    return amount * rate.rate;
+  }
+}

--- a/src/transactions/services/transaction.service.spec.ts
+++ b/src/transactions/services/transaction.service.spec.ts
@@ -30,6 +30,7 @@ import { BeneficiariesService } from '../../beneficiaries/beneficiaries.service'
 import { WalletsService } from '../../wallets/wallets.service';
 import { EncryptionService } from '../../common/services/encryption.service';
 import { LedgerService } from '../../ledger/services/ledger.service';
+import { TransactionLimitService } from './transaction-limit.service';
 
 describe('TransactionsService fee integration behavior', () => {
   let service: TransactionsService;
@@ -136,6 +137,9 @@ describe('TransactionsService fee integration behavior', () => {
   const ledgerService = {
     record: jest.fn(async () => undefined),
   };
+  const transactionLimitService = {
+    check: jest.fn(async () => undefined),
+  };
   const queryRunner = {
     connect: jest.fn(async () => undefined),
     startTransaction: jest.fn(async () => undefined),
@@ -177,6 +181,7 @@ describe('TransactionsService fee integration behavior', () => {
         { provide: WalletsService, useValue: walletsService },
         { provide: EncryptionService, useValue: encryptionService },
         { provide: LedgerService, useValue: ledgerService },
+        { provide: TransactionLimitService, useValue: transactionLimitService },
       ],
     }).compile();
 

--- a/src/transactions/services/transaction.service.ts
+++ b/src/transactions/services/transaction.service.ts
@@ -48,6 +48,7 @@ import { WebhookService } from '../../webhooks/services/webhook.service';
 import { WalletsService } from '../../wallets/wallets.service';
 import { EncryptionService } from '../../common/services/encryption.service';
 import { LedgerService } from '../../ledger/services/ledger.service';
+import { TransactionLimitService } from './transaction-limit.service';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -158,6 +159,7 @@ export class TransactionsService {
     private readonly walletsService: WalletsService,
     private readonly encryptionService: EncryptionService,
     private readonly ledgerService: LedgerService,
+    private readonly transactionLimitService: TransactionLimitService,
   ) {}
 
   /**
@@ -174,6 +176,8 @@ export class TransactionsService {
     this.logger.log(
       `Creating deposit for user ${userId}: ${amount} ${currency}`,
     );
+
+    await this.transactionLimitService.check(userId, amount, currency);
 
     const currencyData = await this.currenciesService.findOne(currency);
     if (!currencyData || !currencyData.isActive) {
@@ -364,6 +368,8 @@ export class TransactionsService {
       throw new NotFoundException('User not found');
     }
 
+    await this.transactionLimitService.check(userId, amount, currency);
+
     const userBalance = await this.getUserBalance(userId, currency);
     if (parseFloat(userBalance) < amount) {
       await this.auditLogsService.logTransactionEvent(
@@ -548,6 +554,8 @@ export class TransactionsService {
     this.logger.log(
       `Creating swap for user ${userId}: ${amount} ${fromCurrency} to ${toCurrency}`,
     );
+
+    await this.transactionLimitService.check(userId, amount, fromCurrency);
 
     if (fromCurrency === toCurrency) {
       throw new BadRequestException(

--- a/src/transactions/services/transaction.swap.spec.ts
+++ b/src/transactions/services/transaction.swap.spec.ts
@@ -27,6 +27,7 @@ import { FirebaseService } from '../../firebase/firebase.service';
 import { WebhookService } from '../../webhooks/services/webhook.service';
 import { BeneficiariesService } from '../../beneficiaries/beneficiaries.service';
 import { LedgerService } from '../../ledger/services/ledger.service';
+import { TransactionLimitService } from './transaction-limit.service';
 
 // Mock Stellar SDK components
 jest.mock('stellar-sdk', () => {
@@ -184,6 +185,10 @@ describe('TransactionsService.createSwap', () => {
         },
         { provide: BeneficiariesService, useValue: {} },
         { provide: LedgerService, useValue: ledgerService },
+        {
+          provide: TransactionLimitService,
+          useValue: { check: jest.fn(async () => undefined) },
+        },
       ],
     }).compile();
 

--- a/src/transactions/transaction-limits.module.ts
+++ b/src/transactions/transaction-limits.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ExchangeRatesModule } from '../exchange-rates/exchange-rates.module';
+import { User } from '../users/user.entity';
+import { Transaction } from './entities/transaction.entity';
+import { TransactionLimit } from './entities/transaction-limit.entity';
+import { TransactionLimitService } from './services/transaction-limit.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User, Transaction, TransactionLimit]),
+    ExchangeRatesModule,
+  ],
+  providers: [TransactionLimitService],
+  exports: [TransactionLimitService],
+})
+export class TransactionLimitsModule {}

--- a/src/transactions/transaction.module.ts
+++ b/src/transactions/transaction.module.ts
@@ -18,6 +18,7 @@ import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 import { FirebaseModule } from '../firebase/firebase.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { CommonModule } from '../common/common.module';
+import { TransactionLimitsModule } from './transaction-limits.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { CommonModule } from '../common/common.module';
     FirebaseModule,
     WebhooksModule,
     CommonModule,
+    TransactionLimitsModule,
   ],
   controllers: [TransactionsController],
   providers: [TransactionsService, TransactionVerificationService],

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -24,6 +24,13 @@ export enum UserPlan {
   ENTERPRISE = 'ENTERPRISE',
 }
 
+export enum UserKycTier {
+  UNVERIFIED = 'UNVERIFIED',
+  BASIC = 'BASIC',
+  ENHANCED = 'ENHANCED',
+  FULL = 'FULL',
+}
+
 @Entity('users')
 export class User {
   @PrimaryGeneratedColumn('uuid')
@@ -78,6 +85,13 @@ export class User {
 
   @Column({ type: 'boolean', default: false })
   isVerified: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: UserKycTier,
+    default: UserKycTier.UNVERIFIED,
+  })
+  kycTier: UserKycTier;
 
   @Column({ type: 'boolean', default: false })
   isSuspended: boolean;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -30,6 +30,7 @@ import {
 } from './dto';
 import { DataExportService } from './services/data-export.service';
 import { AccountDeletionService } from './services/account-deletion.service';
+import { TransactionLimitService } from '../transactions/services/transaction-limit.service';
 
 @ApiTags('Users')
 @Controller('users')
@@ -39,6 +40,7 @@ export class UsersController {
     private readonly usersService: UsersService,
     private readonly dataExportService: DataExportService,
     private readonly accountDeletionService: AccountDeletionService,
+    private readonly transactionLimitService: TransactionLimitService,
   ) {}
 
   @Get('profile')
@@ -254,5 +256,17 @@ export class UsersController {
     @Request() req: { user: { userId: string } },
   ): Promise<RateLimitStatusDto> {
     return this.usersService.getRateLimitStatus(req.user.userId);
+  }
+
+  @Get('me/transaction-limits')
+  @ApiOperation({ summary: 'Get current user KYC-based transaction limits' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns user tier, configured limits, and current usage',
+  })
+  async getTransactionLimits(
+    @Request() req: { user: { userId: string } },
+  ): Promise<Record<string, unknown>> {
+    return this.transactionLimitService.getUserLimitStatus(req.user.userId);
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -18,6 +18,7 @@ import { BlockchainModule } from '../blockchain/blockchain.module';
 import { ExchangeRatesModule } from '../exchange-rates/exchange-rates.module';
 import { TokensModule } from '../tokens/tokens.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { TransactionLimitsModule } from '../transactions/transaction-limits.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     ExchangeRatesModule,
     TokensModule,
     NotificationsModule,
+    TransactionLimitsModule,
   ],
   controllers: [UsersController],
   providers: [

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -3,7 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ThrottlerStorageService } from '@nestjs/throttler';
 import { UsersService } from './users.service';
-import { User, UserRole, UserPlan } from './user.entity';
+import { User, UserRole, UserPlan, UserKycTier } from './user.entity';
 import { RateLimitConfig } from './rate-limit-config.entity';
 import { StellarService } from '../blockchain/stellar/stellar.service';
 import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
@@ -26,6 +26,7 @@ describe('UsersService', () => {
     referralCode: 'ABC12345',
     referredBy: null,
     isVerified: true,
+    kycTier: UserKycTier.ENHANCED,
     isSuspended: false,
     isTwoFactorEnabled: false,
     role: UserRole.USER,


### PR DESCRIPTION
## Description
- add `UserKycTier` model and persisted `kycTier` on users
- - add DB-backed `transaction_limits` configuration per KYC tier
- - seed default tier limits in migration
- - add `TransactionLimitService` with DB SUM aggregation and USD normalization
- - enforce limit checks before deposit, withdrawal, and swap creation
- - return `422` with `DAILY_LIMIT_EXCEEDED` / `MONTHLY_LIMIT_EXCEEDED` / `SINGLE_TX_LIMIT_EXCEEDED` and `remainingAllowance`
- - add admin CRUD endpoints for tier limits:
-   - `GET /admin/transaction-limits`
-   - `POST /admin/transaction-limits`
-   - `PATCH /admin/transaction-limits/:tier`
- - add user endpoint `GET /users/me/transaction-limits`
- - set user `kycTier` during KYC approval based on submitted documents
## Related Issue
Closes #308 
## Type of Change
- [x] New feature
- [ ] - [x] Test
## Testing Steps
- `npm test -- --runInBand`
- - result: 35 suites passed, 202 tests passed
## Checklist
- [x] code follows project standards
- [ ] - [x] self-review completed
- [ ] - [x] tests pass locally