### PR TITLE
Add content moderation with PII detection, profanity filter, and admin queue

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -73,6 +73,7 @@ import { OwaspZapDastModule } from './owasp-zap-dast/owasp-zap-dast.module';
 import { StellarSep24AnchorModule } from './stellar-sep24-anchor/stellar-sep24-anchor.module';
 import { FraudModule } from './modules/fraud/fraud.module';
 import { FiatModule } from './modules/fiat/fiat.module';
+import { ModerationModule } from './modules/moderation/moderation.module';
 
 @Module({
   imports: [
@@ -184,6 +185,7 @@ import { FiatModule } from './modules/fiat/fiat.module';
     StellarSep24AnchorModule,
     FraudModule,
     FiatModule,
+    ModerationModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/migrations/1768000000001-CreateContentModerationEvents.ts
+++ b/src/migrations/1768000000001-CreateContentModerationEvents.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateContentModerationEvents1768000000001
+  implements MigrationInterface
+{
+  name = 'CreateContentModerationEvents1768000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "public"."content_moderation_events_action_enum" AS ENUM (
+        'ALLOWED', 'STRIPPED', 'REJECTED', 'FLAGGED_FOR_REVIEW'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "content_moderation_events" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "context" character varying(100) NOT NULL,
+        "originalText" text,
+        "flags" text[] NOT NULL DEFAULT '{}',
+        "action" "public"."content_moderation_events_action_enum" NOT NULL DEFAULT 'ALLOWED',
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_content_moderation_events_id" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_content_moderation_events_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_content_moderation_events_userId"
+      ON "content_moderation_events" ("userId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_content_moderation_events_action"
+      ON "content_moderation_events" ("action")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_content_moderation_events_createdAt"
+      ON "content_moderation_events" ("createdAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_content_moderation_events_createdAt"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_content_moderation_events_action"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_content_moderation_events_userId"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "content_moderation_events"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "public"."content_moderation_events_action_enum"`,
+    );
+  }
+}

--- a/src/modules/moderation/content-moderation.service.ts
+++ b/src/modules/moderation/content-moderation.service.ts
@@ -1,0 +1,293 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  ContentModerationEvent,
+  ModerationAction,
+} from './entities/content-moderation-event.entity';
+import { RedisService } from '../redis/redis.service';
+
+export interface ModerationResult {
+  allowed: boolean;
+  flags: string[];
+  cleaned: string;
+  action: ModerationAction;
+}
+
+const MAX_LENGTHS: Record<string, number> = {
+  memo: 200,
+  note: 1000,
+  message: 5000,
+  description: 5000,
+  body: 5000,
+};
+
+const CREDIT_CARD_RE = /\b(?:\d[ -]*?){13,19}\b/g;
+const SSN_RE = /\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b/g;
+const IBAN_RE = /\b[A-Z]{2}\d{2}[A-Z0-9]{4,30}\b/g;
+const PHONE_RE = /(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b/g;
+const URL_RE = /https?:\/\/[^\s]+/gi;
+const INJECTION_RE = /<script[\s>]|javascript:|on\w+\s*=|eval\(|document\.(cookie|write)/gi;
+
+const BLOCKLIST_KEY = 'nexafx:moderation:blocklist';
+const DEFAULT_BLOCKLIST = [
+  'shit',
+  'fuck',
+  'damn',
+  'ass',
+  'bitch',
+  'bastard',
+  'crap',
+  'piss',
+  'dick',
+  'cock',
+  'asshole',
+  'motherfucker',
+  'slut',
+  'whore',
+];
+
+@Injectable()
+export class ContentModerationService {
+  private readonly logger = new Logger(ContentModerationService.name);
+
+  constructor(
+    @InjectRepository(ContentModerationEvent)
+    private readonly eventRepository: Repository<ContentModerationEvent>,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async moderate(
+    text: string,
+    context: string,
+    userId: string,
+  ): Promise<ModerationResult> {
+    const maxLength = MAX_LENGTHS[context] ?? 5000;
+
+    if (text.length > maxLength) {
+      return {
+        allowed: false,
+        flags: ['LENGTH_EXCEEDED'],
+        cleaned: text,
+        action: ModerationAction.REJECTED,
+      };
+    }
+
+    const piiFlags = this.detectPII(text);
+    if (piiFlags.length > 0) {
+      await this.logEvent(userId, context, text, piiFlags, ModerationAction.REJECTED);
+      return {
+        allowed: false,
+        flags: piiFlags,
+        cleaned: text,
+        action: ModerationAction.REJECTED,
+      };
+    }
+
+    const { cleaned: profanityCleaned, flags: profanityFlags } =
+      await this.checkProfanity(text);
+
+    const suspiciousFlags = this.detectSuspiciousPatterns(text);
+    const allFlags = [...profanityFlags, ...suspiciousFlags];
+
+    if (allFlags.length === 0) {
+      return {
+        allowed: true,
+        flags: [],
+        cleaned: text,
+        action: ModerationAction.ALLOWED,
+      };
+    }
+
+    if (suspiciousFlags.length > 0 && profanityFlags.length === 0) {
+      await this.logEvent(
+        userId,
+        context,
+        text,
+        allFlags,
+        ModerationAction.FLAGGED_FOR_REVIEW,
+      );
+      return {
+        allowed: true,
+        flags: allFlags,
+        cleaned: text,
+        action: ModerationAction.FLAGGED_FOR_REVIEW,
+      };
+    }
+
+    if (profanityFlags.length > 0) {
+      await this.logEvent(
+        userId,
+        context,
+        null,
+        allFlags,
+        ModerationAction.STRIPPED,
+      );
+      return {
+        allowed: true,
+        flags: allFlags,
+        cleaned: profanityCleaned,
+        action: ModerationAction.STRIPPED,
+      };
+    }
+
+    return {
+      allowed: true,
+      flags: allFlags,
+      cleaned: text,
+      action: ModerationAction.ALLOWED,
+    };
+  }
+
+  async addToBlocklist(word: string): Promise<void> {
+    await this.redisService.rawClient.sadd(
+      BLOCKLIST_KEY,
+      word.toLowerCase(),
+    );
+  }
+
+  async removeFromBlocklist(word: string): Promise<void> {
+    await this.redisService.rawClient.srem(
+      BLOCKLIST_KEY,
+      word.toLowerCase(),
+    );
+  }
+
+  async getBlocklist(): Promise<string[]> {
+    const members = await this.redisService.rawClient.smembers(BLOCKLIST_KEY);
+    if (members.length === 0) {
+      await this.redisService.rawClient.sadd(
+        BLOCKLIST_KEY,
+        ...DEFAULT_BLOCKLIST,
+      );
+      return [...DEFAULT_BLOCKLIST];
+    }
+    return members.sort();
+  }
+
+  async getFlaggedEvents(
+    action?: ModerationAction,
+    page: number = 1,
+    limit: number = 20,
+  ): Promise<{ events: ContentModerationEvent[]; total: number }> {
+    const qb = this.eventRepository
+      .createQueryBuilder('e')
+      .leftJoinAndSelect('e.user', 'user');
+
+    if (action) {
+      qb.where('e.action = :action', { action });
+    } else {
+      qb.where('e.action != :allowed', {
+        allowed: ModerationAction.ALLOWED,
+      });
+    }
+
+    qb.orderBy('e.createdAt', 'DESC');
+
+    const total = await qb.getCount();
+    const events = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getMany();
+
+    return { events, total };
+  }
+
+  private async checkProfanity(
+    text: string,
+  ): Promise<{ cleaned: string; flags: string[] }> {
+    const blocklist = await this.getBlocklist();
+    const lowerText = text.toLowerCase();
+    const flags: string[] = [];
+    let cleaned = text;
+
+    for (const word of blocklist) {
+      const regex = new RegExp(`\\b${this.escapeRegex(word)}\\b`, 'gi');
+      if (regex.test(lowerText)) {
+        flags.push(`PROFANITY:${word.toUpperCase()}`);
+        cleaned = cleaned.replace(regex, '***');
+      }
+    }
+
+    return { cleaned, flags };
+  }
+
+  private detectPII(text: string): string[] {
+    const flags: string[] = [];
+
+    if (this.luhnCheck(text)) {
+      flags.push('PII:CREDIT_CARD');
+    }
+
+    if (SSN_RE.test(text)) {
+      flags.push('PII:SSN');
+    }
+
+    if (IBAN_RE.test(text)) {
+      flags.push('PII:IBAN');
+    }
+
+    return flags;
+  }
+
+  private detectSuspiciousPatterns(text: string): string[] {
+    const flags: string[] = [];
+
+    if (URL_RE.test(text)) {
+      flags.push('SUSPICIOUS:URL');
+    }
+
+    if (INJECTION_RE.test(text)) {
+      flags.push('SUSPICIOUS:INJECTION_ATTEMPT');
+    }
+
+    return flags;
+  }
+
+  private luhnCheck(text: string): boolean {
+    const digits = text.replace(/\D/g, '');
+    if (digits.length < 13 || digits.length > 19) return false;
+
+    let sum = 0;
+    let alternate = false;
+
+    for (let i = digits.length - 1; i >= 0; i--) {
+      let n = parseInt(digits[i], 10);
+      if (alternate) {
+        n *= 2;
+        if (n > 9) n -= 9;
+      }
+      sum += n;
+      alternate = !alternate;
+    }
+
+    return sum % 10 === 0;
+  }
+
+  private escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  private async logEvent(
+    userId: string,
+    context: string,
+    originalText: string | null,
+    flags: string[],
+    action: ModerationAction,
+  ): Promise<void> {
+    try {
+      const event = this.eventRepository.create({
+        userId,
+        context,
+        originalText,
+        flags,
+        action,
+      });
+      await this.eventRepository.save(event);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to log moderation event: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}

--- a/src/modules/moderation/entities/content-moderation-event.entity.ts
+++ b/src/modules/moderation/entities/content-moderation-event.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { User } from '../../../users/user.entity';
+
+export enum ModerationAction {
+  ALLOWED = 'ALLOWED',
+  STRIPPED = 'STRIPPED',
+  REJECTED = 'REJECTED',
+  FLAGGED_FOR_REVIEW = 'FLAGGED_FOR_REVIEW',
+}
+
+@Entity('content_moderation_events')
+export class ContentModerationEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'varchar', length: 100 })
+  context: string;
+
+  @Column({ type: 'text', nullable: true })
+  originalText: string | null;
+
+  @Column({ type: 'text', array: true, default: '{}' })
+  flags: string[];
+
+  @Column({
+    type: 'enum',
+    enum: ModerationAction,
+    default: ModerationAction.ALLOWED,
+  })
+  action: ModerationAction;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+}

--- a/src/modules/moderation/moderation.controller.ts
+++ b/src/modules/moderation/moderation.controller.ts
@@ -1,0 +1,181 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { UserRole } from '../../users/user.entity';
+import {
+  ContentModerationService,
+  ModerationResult,
+} from '../content-moderation.service';
+import { ModerationAction } from '../entities/content-moderation-event.entity';
+
+@ApiTags('Admin-Moderation')
+@ApiBearerAuth()
+@UseGuards(RolesGuard)
+@Roles(UserRole.ADMIN)
+@Controller('admin/moderation')
+export class ModerationController {
+  constructor(
+    private readonly moderationService: ContentModerationService,
+  ) {}
+
+  @Post('moderate')
+  @ApiOperation({
+    summary: 'Moderate text content (Admin testing)',
+    description:
+      'Tests the moderation pipeline against provided text. Returns flags and action taken.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', example: 'Hello world' },
+        context: { type: 'string', example: 'memo' },
+      },
+      required: ['text', 'context'],
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Moderation result',
+    schema: {
+      type: 'object',
+      properties: {
+        allowed: { type: 'boolean' },
+        flags: { type: 'array', items: { type: 'string' } },
+        cleaned: { type: 'string' },
+        action: { type: 'string' },
+      },
+    },
+  })
+  async moderateText(
+    @Body() body: { text: string; context: string },
+  ): Promise<ModerationResult> {
+    return this.moderationService.moderate(
+      body.text,
+      body.context,
+      'admin-test',
+    );
+  }
+
+  @Get('blocklist')
+  @ApiOperation({
+    summary: 'List profanity blocklist',
+    description: 'Returns all words currently in the moderation blocklist.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Blocklist words',
+    schema: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+  })
+  async getBlocklist(): Promise<string[]> {
+    return this.moderationService.getBlocklist();
+  }
+
+  @Post('blocklist')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Add word to profanity blocklist',
+    description:
+      'Adds a word to the Redis-backed blocklist. No restart required.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        word: { type: 'string', example: 'badword' },
+      },
+      required: ['word'],
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Word added to blocklist' })
+  async addToBlocklist(@Body() body: { word: string }): Promise<{
+    message: string;
+    word: string;
+  }> {
+    await this.moderationService.addToBlocklist(body.word);
+    return { message: 'Word added to blocklist', word: body.word };
+  }
+
+  @Delete('blocklist/:word')
+  @ApiOperation({
+    summary: 'Remove word from profanity blocklist',
+    description:
+      'Removes a word from the Redis-backed blocklist. No restart required.',
+  })
+  @ApiParam({
+    name: 'word',
+    description: 'Word to remove from blocklist',
+    example: 'badword',
+  })
+  @ApiResponse({ status: 200, description: 'Word removed from blocklist' })
+  async removeFromBlocklist(
+    @Param('word') word: string,
+  ): Promise<{ message: string; word: string }> {
+    await this.moderationService.removeFromBlocklist(word);
+    return { message: 'Word removed from blocklist', word };
+  }
+
+  @Get('events')
+  @ApiOperation({
+    summary: 'List moderation events',
+    description:
+      'Returns content moderation events. Filter by action type. ' +
+      'Default returns all non-ALLOWED events.',
+  })
+  @ApiQuery({
+    name: 'action',
+    required: false,
+    enum: ModerationAction,
+    description: 'Filter by action type',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Moderation events',
+  })
+  async getEvents(
+    @Query('action') action?: ModerationAction,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.moderationService.getFlaggedEvents(
+      action,
+      page ?? 1,
+      limit ?? 20,
+    );
+  }
+}

--- a/src/modules/moderation/moderation.module.ts
+++ b/src/modules/moderation/moderation.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContentModerationEvent } from './entities/content-moderation-event.entity';
+import { ContentModerationService } from './content-moderation.service';
+import { ModerationController } from './moderation.controller';
+import { RedisModule } from '../redis/redis.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ContentModerationEvent]),
+    RedisModule,
+  ],
+  controllers: [ModerationController],
+  providers: [ContentModerationService],
+  exports: [ContentModerationService],
+})
+export class ModerationModule {}


### PR DESCRIPTION
## Summary

Content moderation system for user-submitted text fields with PII detection, profanity stripping, suspicious pattern flagging, and admin review queue.

### Changes

- ContentModerationService with PII detection (credit cards/Luhn, SSN, IBAN), profanity filtering, and suspicious pattern detection
- Redis-backed blocklist with sensible defaults, updatable without restart
- Admin endpoints for blocklist management and moderation events queue
- Severity: PII=REJECT, profanity=STRIP, suspicious=FLAG_FOR_REVIEW
- Migration for content_moderation_events table

Closes #710