### PR TITLE
Add transaction fee estimation with full cost breakdown

### DIFF
--- a/src/modules/conversions/conversions.controller.ts
+++ b/src/modules/conversions/conversions.controller.ts
@@ -16,13 +16,18 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ConversionsService } from './conversions.service';
 import { CreateQuoteDto } from './dtos/create-quote.dto';
 import { ExecuteConversionDto } from './dtos/execute-conversion.dto';
+import { FeeEstimatorService } from '../../transactions/services/fee-estimator.service';
+import { EstimateConversionDto } from '../../transactions/dtos/fee-estimate.dto';
 
 @ApiTags('Conversions')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('conversions')
 export class ConversionsController {
-  constructor(private readonly conversionsService: ConversionsService) {}
+  constructor(
+    private readonly conversionsService: ConversionsService,
+    private readonly feeEstimatorService: FeeEstimatorService,
+  ) {}
 
   private extractUserId(req: any): string {
     const userId = req.user?.id || req.user?.sub;
@@ -64,5 +69,21 @@ export class ConversionsController {
   async getConversionById(@Req() req: any, @Param('id') id: string) {
     const userId = this.extractUserId(req);
     return this.conversionsService.getConversionById(userId, id);
+  }
+
+  @Post('estimate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Estimate conversion fees',
+    description:
+      'Returns a full fee breakdown for a currency conversion without executing it. ' +
+      'Estimate is valid for 30 seconds.',
+  })
+  async estimateConversion(
+    @Req() req: any,
+    @Body() dto: EstimateConversionDto,
+  ) {
+    const userId = this.extractUserId(req);
+    return this.feeEstimatorService.estimateConversion(userId, dto);
   }
 }

--- a/src/modules/conversions/conversions.module.ts
+++ b/src/modules/conversions/conversions.module.ts
@@ -10,15 +10,22 @@ import { LedgerModule } from '../../ledger/ledger.module';
 import { ConversionsService } from './conversions.service';
 import { ConversionsController } from './conversions.controller';
 import { ConversionsGateway } from './conversions.gateway';
+import { FeeEstimatorService } from '../../transactions/services/fee-estimator.service';
+import { FeesModule } from '../../fees/fees.module';
+import { BlockchainModule } from '../../blockchain/blockchain.module';
+import { RedisModule } from '../redis/redis.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ConversionQuote, Transaction, User, Wallet, LedgerEntry]),
     ExchangeRatesModule,
     LedgerModule,
+    FeesModule,
+    BlockchainModule,
+    RedisModule,
   ],
   controllers: [ConversionsController],
-  providers: [ConversionsService, ConversionsGateway],
+  providers: [ConversionsService, ConversionsGateway, FeeEstimatorService],
   exports: [ConversionsService],
 })
 export class ConversionsModule {}

--- a/src/transactions/controllers/transaction-v2.controller.ts
+++ b/src/transactions/controllers/transaction-v2.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Request } from '@nestjs/common';
+import { Controller, Post, Get, Body, Request, Logger } from '@nestjs/common';
 import {
   ApiTags,
   ApiBearerAuth,
@@ -7,6 +7,17 @@ import {
   ApiHeader,
 } from '@nestjs/swagger';
 import { TransactionsService } from '../services/transaction.service';
+import { FeeEstimatorService } from '../services/fee-estimator.service';
+import {
+  FeeEstimateResult,
+  ConversionEstimateResult,
+  BatchEstimateResult,
+} from '../services/fee-estimator.service';
+import {
+  EstimateTransactionDto,
+  EstimateConversionDto,
+  BatchEstimateDto,
+} from '../dtos/fee-estimate.dto';
 import { CreateDepositDto } from '../dtos/transaction.dto';
 import { TransactionResponseDto } from '../dtos/transaction-response.dto';
 
@@ -14,7 +25,12 @@ import { TransactionResponseDto } from '../dtos/transaction-response.dto';
 @ApiBearerAuth('access-token')
 @Controller({ path: 'transactions', version: '2' })
 export class TransactionV2Controller {
-  constructor(private readonly transactionsService: TransactionsService) {}
+  private readonly logger = new Logger(TransactionV2Controller.name);
+
+  constructor(
+    private readonly transactionsService: TransactionsService,
+    private readonly feeEstimatorService: FeeEstimatorService,
+  ) {}
 
   @Post()
   @ApiHeader({
@@ -44,6 +60,52 @@ export class TransactionV2Controller {
     return this.transactionsService.createDeposit(
       req.user.userId,
       createDepositDto,
+    );
+  }
+
+  @Post('estimate')
+  @ApiOperation({
+    summary: 'Estimate transaction fees',
+    description:
+      'Returns a full fee breakdown for a transaction without executing it. ' +
+      'Estimate is valid for 30 seconds.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Fee estimate with full breakdown',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid estimation parameters',
+  })
+  async estimateTransaction(
+    @Request() req,
+    @Body() dto: EstimateTransactionDto,
+  ): Promise<FeeEstimateResult> {
+    return this.feeEstimatorService.estimateTransaction(req.user.userId, dto);
+  }
+
+  @Post('estimate/batch')
+  @ApiOperation({
+    summary: 'Batch estimate transaction fees',
+    description:
+      'Estimate fees for up to 20 transactions at once. Useful for payroll previews.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Batch fee estimates with total fees',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid batch parameters or exceeds 20 transactions',
+  })
+  async estimateBatch(
+    @Request() req,
+    @Body() dto: BatchEstimateDto,
+  ): Promise<BatchEstimateResult> {
+    return this.feeEstimatorService.estimateBatch(
+      req.user.userId,
+      dto.transactions,
     );
   }
 }

--- a/src/transactions/dtos/fee-estimate.dto.ts
+++ b/src/transactions/dtos/fee-estimate.dto.ts
@@ -1,0 +1,86 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  Min,
+  ValidateNested,
+  ArrayMaxSize,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TransactionType } from '../entities/transaction.entity';
+
+export class EstimateTransactionDto {
+  @ApiProperty({ enum: TransactionType, example: TransactionType.WITHDRAW })
+  @IsEnum(TransactionType)
+  @IsNotEmpty()
+  type: TransactionType;
+
+  @ApiProperty({ example: 100, minimum: 0.01 })
+  @IsNumber()
+  @IsPositive()
+  @Min(0.01)
+  amount: number;
+
+  @ApiProperty({ example: 'XLM' })
+  @IsString()
+  @IsNotEmpty()
+  currency: string;
+
+  @ApiPropertyOptional({ example: 'USDC' })
+  @IsOptional()
+  @IsString()
+  toCurrency?: string;
+}
+
+export class EstimateConversionDto {
+  @ApiProperty({ example: 'XLM' })
+  @IsString()
+  @IsNotEmpty()
+  fromCurrency: string;
+
+  @ApiProperty({ example: 'NGN' })
+  @IsString()
+  @IsNotEmpty()
+  toCurrency: string;
+
+  @ApiProperty({ example: 100, minimum: 0.01 })
+  @IsNumber()
+  @IsPositive()
+  @Min(0.01)
+  fromAmount: number;
+}
+
+export class BatchEstimateItemDto {
+  @ApiProperty({ enum: TransactionType, example: TransactionType.WITHDRAW })
+  @IsEnum(TransactionType)
+  @IsNotEmpty()
+  type: TransactionType;
+
+  @ApiProperty({ example: 50, minimum: 0.01 })
+  @IsNumber()
+  @IsPositive()
+  @Min(0.01)
+  amount: number;
+
+  @ApiProperty({ example: 'XLM' })
+  @IsString()
+  @IsNotEmpty()
+  currency: string;
+
+  @ApiPropertyOptional({ example: 'USDC' })
+  @IsOptional()
+  @IsString()
+  toCurrency?: string;
+}
+
+export class BatchEstimateDto {
+  @ApiProperty({ type: [BatchEstimateItemDto], maxItems: 20 })
+  @ValidateNested({ each: true })
+  @Type(() => BatchEstimateItemDto)
+  @ArrayMaxSize(20)
+  transactions: BatchEstimateItemDto[];
+}

--- a/src/transactions/services/fee-estimator.service.ts
+++ b/src/transactions/services/fee-estimator.service.ts
@@ -1,0 +1,330 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  Transaction,
+  TransactionType,
+} from '../entities/transaction.entity';
+import { FeesService, CalculatedFee } from '../../fees/fees.service';
+import { FeeTransactionType } from '../../fees/entities/fee-config.entity';
+import { ExchangeRatesService } from '../../exchange-rates/exchange-rates.service';
+import { StellarService } from '../../modules/stellar/stellar.service';
+import { RedisService } from '../../modules/redis/redis.service';
+import Decimal from 'decimal.js';
+
+export interface FeeBreakdown {
+  amount: string;
+  currency: string;
+  percent?: string;
+}
+
+export interface FeeEstimateResult {
+  fromAmount: string;
+  fromCurrency: string;
+  toAmount: string;
+  toCurrency: string;
+  recipient: {
+    receives: string;
+    currency: string;
+  };
+  fees: {
+    platformFee: FeeBreakdown;
+    networkFee: FeeBreakdown;
+    markupFee: FeeBreakdown;
+    total: FeeBreakdown;
+  };
+  exchangeRate: number | null;
+  totalDeducted: string;
+  validForSeconds: number;
+}
+
+export interface ConversionEstimateResult {
+  fromAmount: string;
+  fromCurrency: string;
+  toAmount: string;
+  toCurrency: string;
+  fees: {
+    conversionFee: FeeBreakdown;
+    platformFee: FeeBreakdown;
+    total: FeeBreakdown;
+  };
+  exchangeRate: number;
+  totalDeducted: string;
+  validForSeconds: number;
+}
+
+export interface BatchEstimateResult {
+  estimates: FeeEstimateResult[];
+  totalFees: string;
+  feeCurrency: string;
+}
+
+const ESTIMATE_TTL_SECONDS = 30;
+const MARKUP_PERCENT = 0.35;
+const STELLAR_NETWORK_FEE = '0.00001';
+
+@Injectable()
+export class FeeEstimatorService {
+  private readonly logger = new Logger(FeeEstimatorService.name);
+
+  constructor(
+    @InjectRepository(Transaction)
+    private readonly transactionRepository: Repository<Transaction>,
+    private readonly feesService: FeesService,
+    private readonly exchangeRatesService: ExchangeRatesService,
+    private readonly stellarService: StellarService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async estimateTransaction(
+    userId: string,
+    params: {
+      type: TransactionType;
+      amount: number;
+      currency: string;
+      toCurrency?: string;
+    },
+  ): Promise<FeeEstimateResult> {
+    const fromCurrency = params.currency.toUpperCase();
+    const toCurrency = (params.toCurrency ?? params.currency).toUpperCase();
+
+    const platformFee = await this.feesService.calculateFee(
+      this.mapTransactionType(params.type),
+      fromCurrency,
+      params.amount,
+    );
+
+    const networkFeeDecimal = new Decimal(STELLAR_NETWORK_FEE);
+
+    const markupAmount = new Decimal(params.amount)
+      .times(MARKUP_PERCENT)
+      .div(100)
+      .toDecimalPlaces(8);
+
+    const totalFees = new Decimal(platformFee.feeAmount)
+      .plus(networkFeeDecimal)
+      .plus(markupAmount);
+
+    const toAmount = new Decimal(params.amount).minus(totalFees);
+
+    if (toAmount.isNegative()) {
+      throw new BadRequestException(
+        'Insufficient amount: total fees exceed the transaction amount',
+      );
+    }
+
+    const result: FeeEstimateResult = {
+      fromAmount: params.amount.toFixed(8),
+      fromCurrency,
+      toAmount: toAmount.toFixed(8),
+      toCurrency,
+      recipient: {
+        receives: toAmount.toFixed(8),
+        currency: toCurrency,
+      },
+      fees: {
+        platformFee: {
+          amount: platformFee.feeAmount.toFixed(8),
+          currency: fromCurrency,
+          percent: platformFee.feeType === 'PERCENTAGE'
+            ? this.getFeePercentage(platformFee)
+            : undefined,
+        },
+        networkFee: {
+          amount: networkFeeDecimal.toFixed(8),
+          currency: fromCurrency,
+        },
+        markupFee: {
+          amount: markupAmount.toFixed(8),
+          currency: fromCurrency,
+          percent: MARKUP_PERCENT.toString(),
+        },
+        total: {
+          amount: totalFees.toFixed(8),
+          currency: fromCurrency,
+        },
+      },
+      exchangeRate: null,
+      totalDeducted: params.amount.toFixed(8),
+      validForSeconds: ESTIMATE_TTL_SECONDS,
+    };
+
+    const cacheKey = this.redisService.key(
+      'estimate',
+      `${userId}:${this.hashParams(params)}`,
+    );
+    await this.redisService.setJson(cacheKey, result, ESTIMATE_TTL_SECONDS);
+
+    return result;
+  }
+
+  async estimateConversion(
+    userId: string,
+    params: {
+      fromCurrency: string;
+      toCurrency: string;
+      fromAmount: number;
+    },
+  ): Promise<ConversionEstimateResult> {
+    const fromCurrency = params.fromCurrency.toUpperCase();
+    const toCurrency = params.toCurrency.toUpperCase();
+
+    const rateResponse = await this.exchangeRatesService.getRate(
+      fromCurrency,
+      toCurrency,
+    );
+    const baseRate = rateResponse.rate;
+
+    const markupRate = new Decimal(baseRate)
+      .times(new Decimal(1).plus(new Decimal(MARKUP_PERCENT).div(100)))
+      .toDecimalPlaces(8)
+      .toNumber();
+
+    const grossToAmount = new Decimal(params.fromAmount).times(markupRate);
+
+    const conversionFeePercent = parseFloat(
+      process.env.CONVERSION_FEE_PERCENT ?? '0.5',
+    );
+    const conversionFee = grossToAmount
+      .times(conversionFeePercent)
+      .div(100)
+      .toDecimalPlaces(8);
+
+    const platformFeePercent = new Decimal(conversionFeePercent);
+    const platformFeeAmount = grossToAmount
+      .times(platformFeePercent)
+      .div(100)
+      .toDecimalPlaces(8);
+
+    const totalFees = conversionFee.plus(platformFeeAmount);
+    const netToAmount = grossToAmount.minus(totalFees);
+
+    const result: ConversionEstimateResult = {
+      fromAmount: params.fromAmount.toFixed(8),
+      fromCurrency,
+      toAmount: netToAmount.toFixed(8),
+      toCurrency,
+      fees: {
+        conversionFee: {
+          amount: conversionFee.toFixed(8),
+          currency: toCurrency,
+          percent: conversionFeePercent.toString(),
+        },
+        platformFee: {
+          amount: platformFeeAmount.toFixed(8),
+          currency: toCurrency,
+          percent: platformFeePercent.toFixed(1),
+        },
+        total: {
+          amount: totalFees.toFixed(8),
+          currency: toCurrency,
+        },
+      },
+      exchangeRate: markupRate,
+      totalDeducted: params.fromAmount.toFixed(8),
+      validForSeconds: ESTIMATE_TTL_SECONDS,
+    };
+
+    const cacheKey = this.redisService.key(
+      'estimate',
+      `conversion:${userId}:${this.hashParams(params)}`,
+    );
+    await this.redisService.setJson(cacheKey, result, ESTIMATE_TTL_SECONDS);
+
+    return result;
+  }
+
+  async estimateBatch(
+    userId: string,
+    transactions: Array<{
+      type: TransactionType;
+      amount: number;
+      currency: string;
+      toCurrency?: string;
+    }>,
+  ): Promise<BatchEstimateResult> {
+    if (transactions.length > 20) {
+      throw new BadRequestException('Batch estimate is limited to 20 transactions');
+    }
+
+    const estimates = await Promise.all(
+      transactions.map((tx) =>
+        this.estimateTransaction(userId, tx),
+      ),
+    );
+
+    const totalFees = estimates.reduce(
+      (sum, e) => sum.plus(e.fees.total.amount),
+      new Decimal(0),
+    );
+
+    return {
+      estimates,
+      totalFees: totalFees.toFixed(8),
+      feeCurrency: estimates[0]?.fromCurrency ?? 'XLM',
+    };
+  }
+
+  async checkEstimateDrift(
+    userId: string,
+    params: Record<string, unknown>,
+  ): Promise<{ drifted: boolean; currentEstimate: FeeEstimateResult | null }> {
+    const cacheKey = this.redisService.key(
+      'estimate',
+      `${userId}:${this.hashParams(params)}`,
+    );
+    const cached =
+      await this.redisService.getJson<FeeEstimateResult>(cacheKey);
+
+    if (!cached) {
+      return { drifted: false, currentEstimate: null };
+    }
+
+    const currentEstimate = await this.estimateTransaction(userId, {
+      type: params.type as TransactionType,
+      amount: params.amount as number,
+      currency: params.currency as string,
+      toCurrency: params.toCurrency as string | undefined,
+    });
+
+    const oldTotal = new Decimal(cached.fees.total.amount);
+    const newTotal = new Decimal(currentEstimate.fees.total.amount);
+
+    if (oldTotal.isZero()) {
+      return { drifted: false, currentEstimate };
+    }
+
+    const driftPercent = newTotal.minus(oldTotal).abs().div(oldTotal).times(100);
+
+    return {
+      drifted: driftPercent.greaterThan(2),
+      currentEstimate,
+    };
+  }
+
+  private mapTransactionType(type: TransactionType): FeeTransactionType {
+    const mapping: Record<TransactionType, FeeTransactionType> = {
+      [TransactionType.DEPOSIT]: FeeTransactionType.DEPOSIT,
+      [TransactionType.WITHDRAW]: FeeTransactionType.WITHDRAW,
+      [TransactionType.SWAP]: FeeTransactionType.SWAP,
+      [TransactionType.LOAN_DISBURSEMENT]: FeeTransactionType.DEPOSIT,
+      [TransactionType.LOAN_REPAYMENT]: FeeTransactionType.DEPOSIT,
+    };
+    return mapping[type] ?? FeeTransactionType.DEPOSIT;
+  }
+
+  private getFeePercentage(fee: CalculatedFee): string {
+    return fee.feeType === 'PERCENTAGE' ? '0.5' : '0';
+  }
+
+  private hashParams(params: Record<string, unknown>): string {
+    const str = JSON.stringify(params, Object.keys(params).sort());
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash |= 0;
+    }
+    return Math.abs(hash).toString(36);
+  }
+}

--- a/src/transactions/transaction-v2.module.ts
+++ b/src/transactions/transaction-v2.module.ts
@@ -1,9 +1,25 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { TransactionV2Controller } from './controllers/transaction-v2.controller';
 import { TransactionsModule } from '../transactions/transaction.module';
+import { FeeEstimatorService } from './services/fee-estimator.service';
+import { Transaction } from './entities/transaction.entity';
+import { FeesModule } from '../fees/fees.module';
+import { ExchangeRatesModule } from '../exchange-rates/exchange-rates.module';
+import { BlockchainModule } from '../blockchain/blockchain.module';
+import { RedisModule } from '../modules/redis/redis.module';
 
 @Module({
-  imports: [TransactionsModule],
+  imports: [
+    TransactionsModule,
+    TypeOrmModule.forFeature([Transaction]),
+    FeesModule,
+    ExchangeRatesModule,
+    BlockchainModule,
+    RedisModule,
+  ],
   controllers: [TransactionV2Controller],
+  providers: [FeeEstimatorService],
+  exports: [FeeEstimatorService],
 })
 export class TransactionsV2Module {}


### PR DESCRIPTION
Fee estimation endpoint returning full cost breakdown before execution. POST /v2/transactions/estimate, batch estimate, conversion estimate. Redis cached 30s. Decimal.js arithmetic. Closes #711