### PR TITLE
Add automated database index advisor with weekly reports

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -73,6 +73,7 @@ import { OwaspZapDastModule } from './owasp-zap-dast/owasp-zap-dast.module';
 import { StellarSep24AnchorModule } from './stellar-sep24-anchor/stellar-sep24-anchor.module';
 import { FraudModule } from './modules/fraud/fraud.module';
 import { FiatModule } from './modules/fiat/fiat.module';
+import { DbAdvisoryModule } from './modules/db-advisory/db-advisory.module';
 
 @Module({
   imports: [
@@ -184,6 +185,7 @@ import { FiatModule } from './modules/fiat/fiat.module';
     StellarSep24AnchorModule,
     FraudModule,
     FiatModule,
+    DbAdvisoryModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/migrations/1768000000002-CreateIndexAdvisoryReports.ts
+++ b/src/migrations/1768000000002-CreateIndexAdvisoryReports.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateIndexAdvisoryReports1768000000002
+  implements MigrationInterface
+{
+  name = 'CreateIndexAdvisoryReports1768000000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "index_advisory_reports" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "runAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "missingIndexes" jsonb NOT NULL DEFAULT '[]',
+        "unusedIndexes" jsonb NOT NULL DEFAULT '[]',
+        "slowQueries" jsonb NOT NULL DEFAULT '[]',
+        "suggestedMigrations" jsonb NOT NULL DEFAULT '[]',
+        "hasCriticalFindings" boolean NOT NULL DEFAULT false,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_index_advisory_reports_id" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_index_advisory_reports_runAt"
+      ON "index_advisory_reports" ("runAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_index_advisory_reports_runAt"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "index_advisory_reports"`);
+  }
+}

--- a/src/modules/db-advisory/db-advisory.controller.ts
+++ b/src/modules/db-advisory/db-advisory.controller.ts
@@ -1,0 +1,84 @@
+import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { UserRole } from '../../users/user.entity';
+import { IndexAdvisorService } from './index-advisor.service';
+
+@ApiTags('Admin-DB-Advisory')
+@ApiBearerAuth()
+@UseGuards(RolesGuard)
+@Roles(UserRole.ADMIN)
+@Controller('admin/db/index-advisory')
+export class DbAdvisoryController {
+  constructor(private readonly indexAdvisorService: IndexAdvisorService) {}
+
+  @Get('latest')
+  @ApiOperation({
+    summary: 'Get latest index advisory report',
+    description: 'Returns the most recent database index advisory analysis.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Latest advisory report',
+  })
+  async getLatestReport() {
+    return this.indexAdvisorService.getLatestReport();
+  }
+
+  @Get('history')
+  @ApiOperation({
+    summary: 'Get advisory report history',
+    description: 'Returns paginated list of past advisory reports.',
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated advisory reports',
+  })
+  async getReportHistory(
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.indexAdvisorService.getReportHistory(
+      page ?? 1,
+      limit ?? 20,
+    );
+  }
+
+  @Post('run')
+  @ApiOperation({
+    summary: 'Trigger manual index advisory analysis',
+    description:
+      'Runs a full database index advisory analysis and returns the report.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Advisory analysis report',
+  })
+  async runAnalysis() {
+    return this.indexAdvisorService.analyse();
+  }
+
+  @Get('latest/migration')
+  @ApiOperation({
+    summary: 'Get suggested migration SQL',
+    description:
+      'Returns the suggested CREATE INDEX and DROP INDEX statements from the latest report.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Suggested migration SQL',
+  })
+  async getLatestMigration() {
+    const sql = await this.indexAdvisorService.getLatestMigrationSQL();
+    return { sql };
+  }
+}

--- a/src/modules/db-advisory/db-advisory.module.ts
+++ b/src/modules/db-advisory/db-advisory.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IndexAdvisoryReport } from './entities/index-advisory-report.entity';
+import { IndexAdvisorService } from './index-advisor.service';
+import { IndexAdvisorCronService } from './index-advisor-cron.service';
+import { DbAdvisoryController } from './db-advisory.controller';
+import { NotificationsModule } from '../../notifications/notifications.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([IndexAdvisoryReport]),
+    NotificationsModule,
+  ],
+  controllers: [DbAdvisoryController],
+  providers: [IndexAdvisorService, IndexAdvisorCronService],
+  exports: [IndexAdvisorService],
+})
+export class DbAdvisoryModule {}

--- a/src/modules/db-advisory/entities/index-advisory-report.entity.ts
+++ b/src/modules/db-advisory/entities/index-advisory-report.entity.ts
@@ -1,0 +1,56 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+export interface MissingIndex {
+  tableName: string;
+  seqScanCount: number;
+  idxScanCount: number;
+  tableSize: string;
+  suggestedIndex: string;
+}
+
+export interface UnusedIndex {
+  tableName: string;
+  indexName: string;
+  indexSize: string;
+  scanCount: number;
+  suggestedDrop: string;
+}
+
+export interface SlowQuery {
+  query: string;
+  meanExecTimeMs: number;
+  calls: number;
+  totalExecTimeMs: number;
+}
+
+@Entity('index_advisory_reports')
+export class IndexAdvisoryReport {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'timestamp with time zone' })
+  runAt: Date;
+
+  @Column({ type: 'jsonb', default: '[]' })
+  missingIndexes: MissingIndex[];
+
+  @Column({ type: 'jsonb', default: '[]' })
+  unusedIndexes: UnusedIndex[];
+
+  @Column({ type: 'jsonb', default: '[]' })
+  slowQueries: SlowQuery[];
+
+  @Column({ type: 'jsonb', default: '[]' })
+  suggestedMigrations: string[];
+
+  @Column({ type: 'boolean', default: false })
+  hasCriticalFindings: boolean;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+}

--- a/src/modules/db-advisory/index-advisor-cron.service.ts
+++ b/src/modules/db-advisory/index-advisor-cron.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { IndexAdvisorService } from './index-advisor.service';
+
+@Injectable()
+export class IndexAdvisorCronService {
+  private readonly logger = new Logger(IndexAdvisorCronService.name);
+  private isRunning = false;
+
+  constructor(private readonly indexAdvisorService: IndexAdvisorService) {}
+
+  @Cron('0 4 * * 0', { timeZone: 'UTC' })
+  async handleWeeklyAnalysis() {
+    if (this.isRunning) {
+      this.logger.warn('Weekly index advisory analysis already running — skipping');
+      return;
+    }
+
+    this.isRunning = true;
+    this.logger.log('Starting weekly database index advisory analysis');
+
+    try {
+      const report = await this.indexAdvisorService.analyse();
+      this.logger.log(
+        `Weekly analysis complete: ${report.missingIndexes.length} missing, ` +
+          `${report.unusedIndexes.length} unused, ${report.slowQueries.length} slow queries`,
+      );
+    } catch (error: unknown) {
+      this.logger.error(
+        `Weekly index advisory analysis failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}

--- a/src/modules/db-advisory/index-advisor.service.ts
+++ b/src/modules/db-advisory/index-advisor.service.ts
@@ -1,0 +1,278 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DataSource } from 'typeorm';
+import {
+  IndexAdvisoryReport,
+  MissingIndex,
+  UnusedIndex,
+  SlowQuery,
+} from './entities/index-advisory-report.entity';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { NotificationType } from '../../notifications/entities/notification.entity';
+
+@Injectable()
+export class IndexAdvisorService {
+  private readonly logger = new Logger(IndexAdvisorService.name);
+
+  constructor(
+    @InjectRepository(IndexAdvisoryReport)
+    private readonly reportRepository: Repository<IndexAdvisoryReport>,
+    private readonly dataSource: DataSource,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  async analyse(): Promise<IndexAdvisoryReport> {
+    this.logger.log('Starting database index advisory analysis');
+
+    const [missingIndexes, unusedIndexes, slowQueries] = await Promise.all([
+      this.findMissingIndexes(),
+      this.findUnusedIndexes(),
+      this.findSlowQueries(),
+    ]);
+
+    const suggestedMigrations = this.generateMigrationSuggestions(
+      missingIndexes,
+      unusedIndexes,
+    );
+
+    const hasCriticalFindings = slowQueries.some(
+      (q) => q.meanExecTimeMs > 500,
+    );
+
+    const report = this.reportRepository.create({
+      runAt: new Date(),
+      missingIndexes,
+      unusedIndexes,
+      slowQueries,
+      suggestedMigrations,
+      hasCriticalFindings,
+    });
+
+    const saved = await this.reportRepository.save(report);
+
+    this.logger.log(
+      `Index advisory analysis complete: ${missingIndexes.length} missing, ` +
+        `${unusedIndexes.length} unused, ${slowQueries.length} slow queries`,
+    );
+
+    try {
+      await this.sendReportEmail(saved);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to send advisory report email: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return saved;
+  }
+
+  async getLatestReport(): Promise<IndexAdvisoryReport | null> {
+    return this.reportRepository.findOne({
+      order: { runAt: 'DESC' },
+    });
+  }
+
+  async getReportHistory(
+    page: number = 1,
+    limit: number = 20,
+  ): Promise<{ reports: IndexAdvisoryReport[]; total: number }> {
+    const total = await this.reportRepository.count();
+    const reports = await this.reportRepository.find({
+      order: { runAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { reports, total };
+  }
+
+  async getLatestMigrationSQL(): Promise<string> {
+    const report = await this.getLatestReport();
+    if (!report) {
+      return '-- No advisory report available yet. Run analysis first.';
+    }
+
+    const header = [
+      '-- ============================================================',
+      '-- DB Index Advisory — Suggested Migrations',
+      `-- Generated: ${report.runAt.toISOString()}`,
+      '-- WARNING: Review carefully before applying — indexes affect write performance.',
+      '-- ============================================================',
+      '',
+    ].join('\n');
+
+    return header + report.suggestedMigrations.join('\n\n');
+  }
+
+  private async findMissingIndexes(): Promise<MissingIndex[]> {
+    try {
+      const results = await this.dataSource.query(`
+        SELECT
+          schemaname,
+          relname AS tablename,
+          seq_scan,
+          idx_scan,
+          pg_size_pretty(pg_relation_size(relid)) AS table_size,
+          n_live_tup AS row_count
+        FROM pg_stat_user_tables
+        WHERE seq_scan > 1000
+          AND (idx_scan IS NULL OR idx_scan < 100)
+          AND n_live_tup > 10000
+        ORDER BY seq_scan DESC
+        LIMIT 50
+      `);
+
+      return results.map((row: any) => ({
+        tableName: `${row.schemaname}.${row.tablename}`,
+        seqScanCount: parseInt(row.seq_scan, 10),
+        idxScanCount: parseInt(row.idx_scan ?? '0', 10),
+        tableSize: row.table_size,
+        suggestedIndex: this.generateMissingIndexSQL(
+          row.schemaname,
+          row.tablename,
+          row.seq_scan,
+        ),
+      }));
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Could not query missing indexes (pg_stat may not be available): ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return [];
+    }
+  }
+
+  private async findUnusedIndexes(): Promise<UnusedIndex[]> {
+    try {
+      const results = await this.dataSource.query(`
+        SELECT
+          schemaname,
+          relname AS tablename,
+          indexrelname AS indexname,
+          idx_scan,
+          pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
+        FROM pg_stat_user_indexes
+        WHERE idx_scan = 0
+          AND pg_relation_size(indexrelid) > 1048576
+          AND indexrelname NOT LIKE '%_pkey'
+        ORDER BY pg_relation_size(indexrelid) DESC
+        LIMIT 50
+      `);
+
+      return results.map((row: any) => ({
+        tableName: `${row.schemaname}.${row.tablename}`,
+        indexName: row.indexname,
+        indexSize: row.index_size,
+        scanCount: parseInt(row.idx_scan, 10),
+        suggestedDrop: `DROP INDEX IF EXISTS "${row.schemaname}"."${row.indexname}";`,
+      }));
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Could not query unused indexes: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return [];
+    }
+  }
+
+  private async findSlowQueries(): Promise<SlowQuery[]> {
+    try {
+      const hasPgStatStatements = await this.dataSource.query(`
+        SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'
+      `);
+
+      if (!hasPgStatStatements.length) {
+        this.logger.warn(
+          'pg_stat_statements extension not available — skipping slow query analysis',
+        );
+        return [];
+      }
+
+      const results = await this.dataSource.query(`
+        SELECT
+          query,
+          mean_exec_time,
+          calls,
+          total_exec_time
+        FROM pg_stat_statements
+        WHERE mean_exec_time > 100
+          AND calls > 100
+          AND dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
+        ORDER BY mean_exec_time DESC
+        LIMIT 50
+      `);
+
+      return results.map((row: any) => ({
+        query: row.query.substring(0, 500),
+        meanExecTimeMs: parseFloat(row.mean_exec_time),
+        calls: parseInt(row.calls, 10),
+        totalExecTimeMs: parseFloat(row.total_exec_time),
+      }));
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Could not query slow queries: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return [];
+    }
+  }
+
+  private generateMigrationSuggestions(
+    missingIndexes: MissingIndex[],
+    unusedIndexes: UnusedIndex[],
+  ): string[] {
+    const migrations: string[] = [];
+
+    for (const missing of missingIndexes) {
+      migrations.push(missing.suggestedIndex);
+    }
+
+    for (const unused of unusedIndexes) {
+      migrations.push(unused.suggestedDrop);
+    }
+
+    return migrations;
+  }
+
+  private generateMissingIndexSQL(
+    schema: string,
+    tableName: string,
+    seqScanCount: number,
+  ): string {
+    const indexName = `idx_${tableName}_auto_advisory`;
+    const condition =
+      seqScanCount > 5000 ? 'WHERE created_at > NOW() - INTERVAL \'90 days\'' : '';
+
+    return `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${schema}"."${indexName}" ON "${schema}"."${tableName}" (created_at DESC) ${condition};`;
+  }
+
+  private async sendReportEmail(report: IndexAdvisoryReport): Promise<void> {
+    const dbAdminEmails = process.env.DB_ADMIN_EMAILS;
+    if (!dbAdminEmails) {
+      this.logger.debug('DB_ADMIN_EMAILS not configured — skipping email');
+      return;
+    }
+
+    const severity = report.hasCriticalFindings ? 'CRITICAL' : 'INFO';
+    const summary = [
+      `${severity}: Database Index Advisory Report`,
+      `Run at: ${report.runAt.toISOString()}`,
+      '',
+      `Missing indexes: ${report.missingIndexes.length}`,
+      `Unused indexes: ${report.unusedIndexes.length}`,
+      `Slow queries: ${report.slowQueries.length}`,
+    ];
+
+    if (report.hasCriticalFindings) {
+      const criticalQueries = report.slowQueries.filter(
+        (q) => q.meanExecTimeMs > 500,
+      );
+      summary.push('');
+      summary.push('CRITICAL slow queries (>500ms mean):');
+      for (const q of criticalQueries) {
+        summary.push(`  - ${q.meanExecTimeMs.toFixed(1)}ms avg (${q.calls} calls): ${q.query.substring(0, 100)}...`);
+      }
+    }
+
+    this.logger.log(
+      `Advisory report email would be sent to: ${dbAdminEmails}\n${summary.join('\n')}`,
+    );
+  }
+}


### PR DESCRIPTION
Automated DB index advisor querying pg_stat for missing/unused indexes and slow queries. Weekly cron, admin endpoints, migration SQL generation. Closes #712