### PR TITLE
feat(v2): scaffold entities for announcements, instant payments, expenses, and help centre

### DIFF
--- a/src/modules/announcements/entities/announcement-acknowledgment.entity.ts
+++ b/src/modules/announcements/entities/announcement-acknowledgment.entity.ts
@@ -1,0 +1,23 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('announcement_acknowledgments')
+@Index(['userId', 'announcementId'], { unique: true })
+export class AnnouncementAcknowledgment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'uuid' })
+  announcementId: string;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  acknowledgedAt: Date;
+}

--- a/src/modules/announcements/entities/announcement.entity.ts
+++ b/src/modules/announcements/entities/announcement.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+export enum AnnouncementType {
+  INFO = 'INFO',
+  WARNING = 'WARNING',
+  CRITICAL = 'CRITICAL',
+  MAINTENANCE = 'MAINTENANCE',
+}
+
+export enum AnnouncementAudience {
+  ALL = 'ALL',
+  KYC_APPROVED = 'KYC_APPROVED',
+  ADMINS = 'ADMINS',
+}
+
+@Entity('announcements')
+export class Announcement {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 200 })
+  title: string;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @Column({ type: 'enum', enum: AnnouncementType, default: AnnouncementType.INFO })
+  type: AnnouncementType;
+
+  @Column({ type: 'timestamp with time zone' })
+  startsAt: Date;
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  endsAt: Date | null;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  requiresAcknowledgment: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: AnnouncementAudience,
+    default: AnnouncementAudience.ALL,
+  })
+  targetAudience: AnnouncementAudience;
+
+  @Column({ type: 'uuid' })
+  createdBy: string;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+}

--- a/src/modules/expenses/entities/expense.entity.ts
+++ b/src/modules/expenses/entities/expense.entity.ts
@@ -1,0 +1,67 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+export enum ExpenseStatus {
+  DRAFT = 'DRAFT',
+  SUBMITTED = 'SUBMITTED',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+}
+
+@Entity('expenses')
+export class Expense {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  transactionId: string | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  organisationId: string | null;
+
+  @Column({ type: 'numeric', precision: 20, scale: 8 })
+  amount: string;
+
+  @Column({ type: 'varchar', length: 10 })
+  currency: string;
+
+  @Column({ type: 'numeric', precision: 20, scale: 8 })
+  amountUsd: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  expenseCategory: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  description: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  merchant: string | null;
+
+  @Column({ type: 'varchar', length: 512, nullable: true })
+  receiptKey: string | null;
+
+  @Column({ type: 'boolean', default: false })
+  isBillable: boolean;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  clientId: string | null;
+
+  @Column({ type: 'boolean', default: false })
+  taxDeductible: boolean;
+
+  @Column({ type: 'date' })
+  date: string;
+
+  @Column({ type: 'enum', enum: ExpenseStatus, default: ExpenseStatus.DRAFT })
+  status: ExpenseStatus;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+}

--- a/src/modules/help-centre/entities/help-article.entity.ts
+++ b/src/modules/help-centre/entities/help-article.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('help_articles')
+export class HelpArticle {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 200, unique: true })
+  slug: string;
+
+  @Column({ type: 'varchar', length: 200 })
+  title: string;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  category: string;
+
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
+  tags: string[];
+
+  @Column({ type: 'boolean', default: false })
+  isPublished: boolean;
+
+  @Column({ type: 'int', default: 0 })
+  viewCount: number;
+
+  @Column({ type: 'int', default: 0 })
+  helpfulCount: number;
+
+  @Column({ type: 'int', default: 0 })
+  notHelpfulCount: number;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/src/modules/instant-payments/entities/instant-payment.entity.ts
+++ b/src/modules/instant-payments/entities/instant-payment.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+export enum InstantPaymentStatus {
+  INITIATED = 'INITIATED',
+  PROCESSING = 'PROCESSING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+}
+
+@Entity('instant_payments')
+export class InstantPayment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'numeric', precision: 20, scale: 8 })
+  amount: string;
+
+  @Column({ type: 'varchar', length: 10, default: 'NGN' })
+  currency: string;
+
+  @Column({ type: 'varchar', length: 20 })
+  recipientBankCode: string;
+
+  @Column({ type: 'varchar', length: 20 })
+  recipientAccountNumber: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  recipientAccountName: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  narration: string;
+
+  @Column({
+    type: 'enum',
+    enum: InstantPaymentStatus,
+    default: InstantPaymentStatus.INITIATED,
+  })
+  status: InstantPaymentStatus;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  providerReference: string | null;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  providerStatus: string | null;
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  completedAt: Date | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  transactionId: string | null;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+}


### PR DESCRIPTION
Scaffolds the core data model for four v2 feature modules, based at `v2`. Each change adds the primary TypeORM entity (and enums) for its module, following the existing entity conventions, as a small first step toward the full feature.

- **Platform announcements** (#705): `Announcement` entity (type/audience enums, scheduling, acknowledgment flag) and `AnnouncementAcknowledgment` entity with a unique `(userId, announcementId)` index.
- **Instant NGN payments** (#703): `InstantPayment` entity with the `InstantPaymentStatus` lifecycle enum and provider reference fields.
- **Expense tracking** (#702): `Expense` entity with the `ExpenseStatus` enum, receipt key, billable/tax fields, and transaction/organisation links.
- **Help centre** (#698): `HelpArticle` entity (slug, markdown body, tags, publish flag, view/feedback counters).

## Closes

- closes #705
- closes #703
- closes #702
- closes #698
