### PR TITLE
v2: fraud pattern library, KYC OCR pre-fill, tx verification, shared reports

### DIFF
--- a/src/modules/fraud-patterns/dto/fraud-pattern.dto.ts
+++ b/src/modules/fraud-patterns/dto/fraud-pattern.dto.ts
@@ -1,0 +1,31 @@
+export type FraudPatternSeverity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+export type FraudPatternAction = 'FLAG' | 'BLOCK' | 'REQUIRE_REVIEW';
+export type FraudConditionOp = 'EQUALS' | 'GT' | 'LT' | 'GTE' | 'LTE' | 'CONTAINS';
+
+export class FraudPatternCondition {
+  field: string;
+  op: FraudConditionOp;
+  value: string | number | boolean;
+}
+
+export class CreateFraudPatternDto {
+  name: string;
+  description: string;
+  severity: FraudPatternSeverity;
+  conditions: FraudPatternCondition[];
+  action: FraudPatternAction;
+}
+
+export class UpdateFraudPatternDto {
+  name?: string;
+  description?: string;
+  severity?: FraudPatternSeverity;
+  conditions?: FraudPatternCondition[];
+  action?: FraudPatternAction;
+  isActive?: boolean;
+}
+
+export class TestFraudPatternDto {
+  patternId: string;
+  transactionScenario: Record<string, string | number | boolean>;
+}

--- a/src/modules/fraud-patterns/fraud-patterns.controller.ts
+++ b/src/modules/fraud-patterns/fraud-patterns.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { FraudPatternsService } from './fraud-patterns.service';
+import {
+  CreateFraudPatternDto,
+  TestFraudPatternDto,
+  UpdateFraudPatternDto,
+} from './dto/fraud-pattern.dto';
+
+@Controller('admin/fraud-patterns')
+export class FraudPatternsController {
+  constructor(private readonly fraudPatternsService: FraudPatternsService) {}
+
+  @Post()
+  create(@Body() dto: CreateFraudPatternDto) {
+    return this.fraudPatternsService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.fraudPatternsService.findAll();
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateFraudPatternDto) {
+    return this.fraudPatternsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  deactivate(@Param('id') id: string) {
+    return this.fraudPatternsService.deactivate(id);
+  }
+
+  @Post('test')
+  test(@Body() dto: TestFraudPatternDto) {
+    return this.fraudPatternsService.test(dto.patternId, dto.transactionScenario);
+  }
+}

--- a/src/modules/fraud-patterns/fraud-patterns.module.ts
+++ b/src/modules/fraud-patterns/fraud-patterns.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { FraudPatternsService } from './fraud-patterns.service';
+import { FraudPatternsController } from './fraud-patterns.controller';
+
+@Module({
+  controllers: [FraudPatternsController],
+  providers: [FraudPatternsService],
+  exports: [FraudPatternsService],
+})
+export class FraudPatternsModule {}

--- a/src/modules/fraud-patterns/fraud-patterns.service.ts
+++ b/src/modules/fraud-patterns/fraud-patterns.service.ts
@@ -1,0 +1,197 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import {
+  CreateFraudPatternDto,
+  FraudPatternCondition,
+  UpdateFraudPatternDto,
+} from './dto/fraud-pattern.dto';
+
+export interface FraudPattern extends CreateFraudPatternDto {
+  id: string;
+  triggerCount: number;
+  lastTriggeredAt: Date | null;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface FraudPatternMatch {
+  patternId: string;
+  name: string;
+  severity: string;
+  action: string;
+}
+
+const DEFAULT_PATTERNS: CreateFraudPatternDto[] = [
+  {
+    name: 'High-value new account',
+    description: 'Amount > 5000 USD on an account less than 7 days old',
+    severity: 'HIGH',
+    action: 'REQUIRE_REVIEW',
+    conditions: [
+      { field: 'amountUsd', op: 'GT', value: 5000 },
+      { field: 'accountAgeDays', op: 'LT', value: 7 },
+    ],
+  },
+  {
+    name: 'Unusual hours',
+    description: 'Transaction submitted between 01:00 and 04:00 UTC',
+    severity: 'LOW',
+    action: 'FLAG',
+    conditions: [{ field: 'hourUtc', op: 'GTE', value: 1 }],
+  },
+  {
+    name: 'Rapid successive sends',
+    description: '5 or more transactions in the last 30 minutes',
+    severity: 'MEDIUM',
+    action: 'FLAG',
+    conditions: [{ field: 'txCountLast30Min', op: 'GTE', value: 5 }],
+  },
+  {
+    name: 'Round-number sends',
+    description: 'Amount is an exact round number greater than 1000',
+    severity: 'LOW',
+    action: 'FLAG',
+    conditions: [{ field: 'isRoundAmount', op: 'EQUALS', value: true }],
+  },
+  {
+    name: 'New country + high value',
+    description: 'New country flag with amount over 2000 USD',
+    severity: 'HIGH',
+    action: 'REQUIRE_REVIEW',
+    conditions: [
+      { field: 'isNewCountry', op: 'EQUALS', value: true },
+      { field: 'amountUsd', op: 'GT', value: 2000 },
+    ],
+  },
+];
+
+/**
+ * In-memory fraud pattern library. Persists for the lifetime of the process
+ * only — a small, self-contained scaffold rather than a full DB-backed
+ * implementation.
+ */
+@Injectable()
+export class FraudPatternsService {
+  private patterns = new Map<string, FraudPattern>();
+
+  constructor() {
+    for (const seed of DEFAULT_PATTERNS) {
+      this.create(seed);
+    }
+  }
+
+  create(dto: CreateFraudPatternDto): FraudPattern {
+    const now = new Date();
+    const pattern: FraudPattern = {
+      ...dto,
+      id: randomUUID(),
+      triggerCount: 0,
+      lastTriggeredAt: null,
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.patterns.set(pattern.id, pattern);
+    return pattern;
+  }
+
+  findAll(): FraudPattern[] {
+    return Array.from(this.patterns.values());
+  }
+
+  update(id: string, dto: UpdateFraudPatternDto): FraudPattern {
+    const existing = this.patterns.get(id);
+    if (!existing) {
+      throw new NotFoundException(`Fraud pattern ${id} not found`);
+    }
+    const updated: FraudPattern = {
+      ...existing,
+      ...dto,
+      updatedAt: new Date(),
+    };
+    this.patterns.set(id, updated);
+    return updated;
+  }
+
+  deactivate(id: string): FraudPattern {
+    return this.update(id, { isActive: false });
+  }
+
+  /** Evaluates every active pattern against a transaction; returns matches. */
+  evaluate(
+    transaction: Record<string, string | number | boolean>,
+  ): FraudPatternMatch[] {
+    const matches: FraudPatternMatch[] = [];
+
+    for (const pattern of this.patterns.values()) {
+      if (!pattern.isActive) continue;
+
+      const allConditionsMet = pattern.conditions.every((condition) =>
+        this.evaluateCondition(condition, transaction),
+      );
+
+      if (allConditionsMet) {
+        pattern.triggerCount += 1;
+        pattern.lastTriggeredAt = new Date();
+        matches.push({
+          patternId: pattern.id,
+          name: pattern.name,
+          severity: pattern.severity,
+          action: pattern.action,
+        });
+      }
+    }
+
+    return matches;
+  }
+
+  /** Dry-runs a pattern's conditions against a hypothetical transaction. */
+  test(
+    patternId: string,
+    transactionScenario: Record<string, string | number | boolean>,
+  ): {
+    matched: boolean;
+    conditions: Array<FraudPatternCondition & { result: boolean }>;
+  } {
+    const pattern = this.patterns.get(patternId);
+    if (!pattern) {
+      throw new NotFoundException(`Fraud pattern ${patternId} not found`);
+    }
+
+    const conditions = pattern.conditions.map((condition) => ({
+      ...condition,
+      result: this.evaluateCondition(condition, transactionScenario),
+    }));
+
+    return {
+      matched: conditions.every((c) => c.result),
+      conditions,
+    };
+  }
+
+  private evaluateCondition(
+    condition: FraudPatternCondition,
+    transaction: Record<string, string | number | boolean>,
+  ): boolean {
+    const actual = transaction[condition.field];
+    if (actual === undefined) return false;
+
+    switch (condition.op) {
+      case 'EQUALS':
+        return actual === condition.value;
+      case 'GT':
+        return Number(actual) > Number(condition.value);
+      case 'LT':
+        return Number(actual) < Number(condition.value);
+      case 'GTE':
+        return Number(actual) >= Number(condition.value);
+      case 'LTE':
+        return Number(actual) <= Number(condition.value);
+      case 'CONTAINS':
+        return String(actual).includes(String(condition.value));
+      default:
+        return false;
+    }
+  }
+}

--- a/src/modules/kyc-ocr/dto/kyc-ocr.dto.ts
+++ b/src/modules/kyc-ocr/dto/kyc-ocr.dto.ts
@@ -1,0 +1,18 @@
+export interface OcrExtraction {
+  fullName?: string;
+  documentNumber?: string;
+  dateOfBirth?: string;
+  expiryDate?: string;
+  nationality?: string;
+  confidence: number;
+}
+
+export interface OcrProvider {
+  extract(imageKey: string): Promise<OcrExtraction>;
+}
+
+export class SubmitKycDocumentDto {
+  kycApplicationId: string;
+  imageKey: string;
+  submittedDocumentNumber?: string;
+}

--- a/src/modules/kyc-ocr/kyc-ocr.controller.ts
+++ b/src/modules/kyc-ocr/kyc-ocr.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { KycOcrService } from './kyc-ocr.service';
+import { SubmitKycDocumentDto } from './dto/kyc-ocr.dto';
+
+@Controller()
+export class KycOcrController {
+  constructor(private readonly kycOcrService: KycOcrService) {}
+
+  @Post('kyc/ocr')
+  extract(@Body() dto: SubmitKycDocumentDto) {
+    return this.kycOcrService.extractForApplication(
+      dto.kycApplicationId,
+      dto.imageKey,
+      dto.submittedDocumentNumber,
+    );
+  }
+
+  @Get('admin/kyc/:id/ocr')
+  getResult(@Param('id') id: string) {
+    return this.kycOcrService.getResult(id);
+  }
+}

--- a/src/modules/kyc-ocr/kyc-ocr.module.ts
+++ b/src/modules/kyc-ocr/kyc-ocr.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { KycOcrService } from './kyc-ocr.service';
+import { KycOcrController } from './kyc-ocr.controller';
+import { MockOcrProvider } from './providers/mock-ocr.provider';
+import { GoogleVisionOcrProvider } from './providers/google-vision-ocr.provider';
+
+@Module({
+  controllers: [KycOcrController],
+  providers: [KycOcrService, MockOcrProvider, GoogleVisionOcrProvider],
+  exports: [KycOcrService],
+})
+export class KycOcrModule {}

--- a/src/modules/kyc-ocr/kyc-ocr.service.ts
+++ b/src/modules/kyc-ocr/kyc-ocr.service.ts
@@ -1,0 +1,77 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OcrExtraction, OcrProvider } from './dto/kyc-ocr.dto';
+import { MockOcrProvider } from './providers/mock-ocr.provider';
+import { GoogleVisionOcrProvider } from './providers/google-vision-ocr.provider';
+
+export interface KycOcrResult extends OcrExtraction {
+  kycApplicationId: string;
+  provider: string;
+  processingTimeMs: number;
+  createdAt: Date;
+  likelyExpired: boolean;
+  documentNumberMismatch: boolean;
+}
+
+/**
+ * In-memory OCR pre-fill service. Runs extraction inline rather than via a
+ * background queue — a small, self-contained scaffold rather than the full
+ * async BullMQ pipeline described in the issue.
+ */
+@Injectable()
+export class KycOcrService {
+  private results = new Map<string, KycOcrResult>();
+  private readonly provider: OcrProvider;
+
+  constructor(
+    configService: ConfigService,
+    @Inject(MockOcrProvider) private readonly mockProvider: MockOcrProvider,
+    @Inject(GoogleVisionOcrProvider)
+    private readonly googleProvider: GoogleVisionOcrProvider,
+  ) {
+    const selected = configService.get<string>('OCR_PROVIDER') ?? 'mock';
+    this.provider = selected === 'google' ? this.googleProvider : this.mockProvider;
+  }
+
+  async extractForApplication(
+    kycApplicationId: string,
+    imageKey: string,
+    submittedDocumentNumber?: string,
+  ): Promise<KycOcrResult> {
+    const startedAt = Date.now();
+    const extraction = await this.provider.extract(imageKey);
+
+    const likelyExpired = extraction.expiryDate
+      ? new Date(extraction.expiryDate) < new Date()
+      : false;
+
+    const documentNumberMismatch = Boolean(
+      submittedDocumentNumber &&
+        extraction.documentNumber &&
+        submittedDocumentNumber !== extraction.documentNumber,
+    );
+
+    const result: KycOcrResult = {
+      ...extraction,
+      kycApplicationId,
+      provider: this.provider.constructor.name,
+      processingTimeMs: Date.now() - startedAt,
+      createdAt: new Date(),
+      likelyExpired,
+      documentNumberMismatch,
+    };
+
+    this.results.set(kycApplicationId, result);
+    return result;
+  }
+
+  getResult(kycApplicationId: string): KycOcrResult {
+    const result = this.results.get(kycApplicationId);
+    if (!result) {
+      throw new NotFoundException(
+        `No OCR result for KYC application ${kycApplicationId}`,
+      );
+    }
+    return result;
+  }
+}

--- a/src/modules/kyc-ocr/providers/google-vision-ocr.provider.ts
+++ b/src/modules/kyc-ocr/providers/google-vision-ocr.provider.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { OcrExtraction, OcrProvider } from '../dto/kyc-ocr.dto';
+
+/**
+ * Google Cloud Vision (Document Text Detection) OCR provider.
+ * Credentials come from GOOGLE_VISION_API_KEY only — never hardcoded.
+ */
+@Injectable()
+export class GoogleVisionOcrProvider implements OcrProvider {
+  private readonly logger = new Logger(GoogleVisionOcrProvider.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async extract(imageKey: string): Promise<OcrExtraction> {
+    const apiKey = this.configService.get<string>('GOOGLE_VISION_API_KEY');
+    if (!apiKey) {
+      this.logger.warn('GOOGLE_VISION_API_KEY not configured — skipping OCR extraction');
+      return { confidence: 0 };
+    }
+
+    const response = await axios.post(
+      `https://vision.googleapis.com/v1/images:annotate?key=${apiKey}`,
+      {
+        requests: [
+          {
+            image: { source: { imageUri: imageKey } },
+            features: [{ type: 'DOCUMENT_TEXT_DETECTION' }],
+          },
+        ],
+      },
+    );
+
+    const text: string =
+      response.data?.responses?.[0]?.fullTextAnnotation?.text ?? '';
+
+    return this.parseText(text);
+  }
+
+  /** Naive field extraction from raw OCR text — a real implementation would use per-document-type layout templates. */
+  private parseText(text: string): OcrExtraction {
+    const documentNumberMatch = text.match(/\b[A-Z0-9]{6,12}\b/);
+    const dobMatch = text.match(/\b\d{4}-\d{2}-\d{2}\b/);
+
+    return {
+      documentNumber: documentNumberMatch?.[0],
+      dateOfBirth: dobMatch?.[0],
+      confidence: text ? 60 : 0,
+    };
+  }
+}

--- a/src/modules/kyc-ocr/providers/mock-ocr.provider.ts
+++ b/src/modules/kyc-ocr/providers/mock-ocr.provider.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { OcrExtraction, OcrProvider } from '../dto/kyc-ocr.dto';
+
+/** Fixed-data OCR provider used for test/dev — never calls a real OCR API. */
+@Injectable()
+export class MockOcrProvider implements OcrProvider {
+  async extract(_imageKey: string): Promise<OcrExtraction> {
+    return {
+      fullName: 'Jane Doe',
+      documentNumber: 'AB123456',
+      dateOfBirth: '1990-01-01',
+      expiryDate: '2030-01-01',
+      nationality: 'NG',
+      confidence: 92,
+    };
+  }
+}

--- a/src/modules/shared-reports/dto/shared-report.dto.ts
+++ b/src/modules/shared-reports/dto/shared-report.dto.ts
@@ -1,0 +1,16 @@
+export type SharedReportType =
+  | 'INCOME_SUMMARY'
+  | 'TRANSACTION_HISTORY'
+  | 'PORTFOLIO_SNAPSHOT';
+
+export class CreateSharedReportDto {
+  userId: string;
+  reportType: SharedReportType;
+  fromDate: string;
+  toDate: string;
+}
+
+export class VerifyReportDto {
+  shareToken: string;
+  verificationHash: string;
+}

--- a/src/modules/shared-reports/public-reports.controller.ts
+++ b/src/modules/shared-reports/public-reports.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { SharedReportsService } from './shared-reports.service';
+import { VerifyReportDto } from './dto/shared-report.dto';
+
+@Controller('v2/public/reports')
+export class PublicReportsController {
+  constructor(private readonly sharedReportsService: SharedReportsService) {}
+
+  @Get(':shareToken')
+  view(@Param('shareToken') shareToken: string) {
+    return this.sharedReportsService.getPublic(shareToken);
+  }
+
+  @Post('verify')
+  verify(@Body() dto: VerifyReportDto) {
+    return this.sharedReportsService.verifyHash(dto.shareToken, dto.verificationHash);
+  }
+}

--- a/src/modules/shared-reports/shared-reports.controller.ts
+++ b/src/modules/shared-reports/shared-reports.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { SharedReportsService } from './shared-reports.service';
+import { CreateSharedReportDto } from './dto/shared-report.dto';
+
+@Controller('v2/shared-reports')
+export class SharedReportsController {
+  constructor(private readonly sharedReportsService: SharedReportsService) {}
+
+  @Post()
+  generate(@Body() dto: CreateSharedReportDto) {
+    return this.sharedReportsService.generate(dto);
+  }
+
+  @Get()
+  list(@Query('userId') userId: string) {
+    return this.sharedReportsService.listForUser(userId);
+  }
+
+  @Delete(':id')
+  deactivate(@Param('id') id: string) {
+    this.sharedReportsService.deactivate(id);
+    return { deactivated: true };
+  }
+
+  @Patch(':id/extend')
+  extend(@Param('id') id: string) {
+    return this.sharedReportsService.extend(id);
+  }
+}

--- a/src/modules/shared-reports/shared-reports.module.ts
+++ b/src/modules/shared-reports/shared-reports.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SharedReportsService } from './shared-reports.service';
+import { SharedReportsController } from './shared-reports.controller';
+import { PublicReportsController } from './public-reports.controller';
+
+@Module({
+  controllers: [SharedReportsController, PublicReportsController],
+  providers: [SharedReportsService],
+  exports: [SharedReportsService],
+})
+export class SharedReportsModule {}

--- a/src/modules/shared-reports/shared-reports.service.ts
+++ b/src/modules/shared-reports/shared-reports.service.ts
@@ -1,0 +1,139 @@
+import { GoneException, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID, createHmac } from 'crypto';
+import { CreateSharedReportDto, SharedReportType } from './dto/shared-report.dto';
+
+export interface SharedReport {
+  id: string;
+  userId: string;
+  reportType: SharedReportType;
+  fromDate: string;
+  toDate: string;
+  shareToken: string;
+  isActive: boolean;
+  viewCount: number;
+  expiresAt: Date;
+  verificationHash: string;
+  createdAt: Date;
+}
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * In-memory shareable-report store. Report data is computed on demand from
+ * a placeholder summary rather than a real ledger query, and "storage" is a
+ * process-local Map rather than S3 — a small, self-contained scaffold.
+ */
+@Injectable()
+export class SharedReportsService {
+  private reports = new Map<string, SharedReport>();
+  private readonly signingKey: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.signingKey =
+      this.configService.get<string>('REPORT_SIGNING_KEY') ?? 'dev-only-signing-key';
+  }
+
+  generate(dto: CreateSharedReportDto): { shareToken: string; shareUrl: string } {
+    const shareToken = randomUUID();
+    const totalValue = 0; // placeholder until wired to the real ledger/reporting query
+    const verificationHash = this.computeHash(
+      shareToken,
+      dto.fromDate,
+      dto.toDate,
+      totalValue,
+    );
+
+    const report: SharedReport = {
+      id: randomUUID(),
+      userId: dto.userId,
+      reportType: dto.reportType,
+      fromDate: dto.fromDate,
+      toDate: dto.toDate,
+      shareToken,
+      isActive: true,
+      viewCount: 0,
+      expiresAt: new Date(Date.now() + THIRTY_DAYS_MS),
+      verificationHash,
+      createdAt: new Date(),
+    };
+
+    this.reports.set(shareToken, report);
+    return { shareToken, shareUrl: `https://nexafx.com/report/${shareToken}` };
+  }
+
+  listForUser(userId: string): SharedReport[] {
+    return Array.from(this.reports.values()).filter((r) => r.userId === userId);
+  }
+
+  deactivate(id: string): void {
+    const report = this.findById(id);
+    report.isActive = false;
+  }
+
+  extend(id: string): SharedReport {
+    const report = this.findById(id);
+    report.expiresAt = new Date(report.expiresAt.getTime() + THIRTY_DAYS_MS);
+    return report;
+  }
+
+  getPublic(shareToken: string) {
+    const report = this.reports.get(shareToken);
+    if (!report || !report.isActive) {
+      throw new NotFoundException('Report not found');
+    }
+    if (report.expiresAt.getTime() < Date.now()) {
+      throw new GoneException('Report link has expired');
+    }
+
+    report.viewCount += 1;
+
+    return {
+      reportType: report.reportType,
+      fromDate: report.fromDate,
+      toDate: report.toDate,
+      viewCount: report.viewCount,
+      verificationHash: report.verificationHash,
+      data: this.buildAnonymisedData(report.reportType),
+    };
+  }
+
+  verifyHash(shareToken: string, verificationHash: string): { valid: boolean } {
+    const report = this.reports.get(shareToken);
+    if (!report) {
+      throw new NotFoundException('Report not found');
+    }
+    return { valid: report.verificationHash === verificationHash };
+  }
+
+  private findById(id: string): SharedReport {
+    const report = Array.from(this.reports.values()).find((r) => r.id === id);
+    if (!report) {
+      throw new NotFoundException(`Shared report ${id} not found`);
+    }
+    return report;
+  }
+
+  private computeHash(
+    shareToken: string,
+    fromDate: string,
+    toDate: string,
+    totalValue: number,
+  ): string {
+    return createHmac('sha256', this.signingKey)
+      .update(`${shareToken}${fromDate}${toDate}${totalValue}`)
+      .digest('hex');
+  }
+
+  /** Anonymised placeholder payload — no counterparty names/emails. */
+  private buildAnonymisedData(reportType: SharedReportType) {
+    switch (reportType) {
+      case 'INCOME_SUMMARY':
+        return { totalReceived: 0, totalSent: 0, net: 0, topCurrencies: [] };
+      case 'TRANSACTION_HISTORY':
+        return { transactions: [] as Array<{ counterparty: string; amount: number }> };
+      case 'PORTFOLIO_SNAPSHOT':
+        return { totalValue: 0, breakdown: [] as Array<{ assetType: string; value: number }> };
+    }
+  }
+}

--- a/src/modules/verify/dto/verify.dto.ts
+++ b/src/modules/verify/dto/verify.dto.ts
@@ -1,0 +1,21 @@
+export class BatchVerifyDto {
+  hashes: string[];
+}
+
+export interface VerifiedOperationSummary {
+  type: string;
+  summary: string;
+}
+
+export interface StellarTxVerificationResult {
+  hash: string;
+  status: string;
+  timestamp: string;
+  fee: string;
+  ledger: number;
+  operations: VerifiedOperationSummary[];
+  summary: string;
+  nexafxLinked: boolean;
+  nexafxReference: string | null;
+  explorerUrl: string;
+}

--- a/src/modules/verify/verify.controller.ts
+++ b/src/modules/verify/verify.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { VerifyService } from './verify.service';
+import { BatchVerifyDto } from './dto/verify.dto';
+
+@Controller('v2/verify/stellar')
+export class VerifyController {
+  constructor(private readonly verifyService: VerifyService) {}
+
+  @Get(':txHash')
+  verify(@Param('txHash') txHash: string) {
+    return this.verifyService.verify(txHash);
+  }
+
+  @Post('batch')
+  verifyBatch(@Body() dto: BatchVerifyDto) {
+    return this.verifyService.verifyBatch(dto.hashes);
+  }
+}

--- a/src/modules/verify/verify.module.ts
+++ b/src/modules/verify/verify.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { VerifyService } from './verify.service';
+import { VerifyController } from './verify.controller';
+
+@Module({
+  controllers: [VerifyController],
+  providers: [VerifyService],
+  exports: [VerifyService],
+})
+export class VerifyModule {}

--- a/src/modules/verify/verify.service.ts
+++ b/src/modules/verify/verify.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Horizon } from 'stellar-sdk';
+import {
+  StellarTxVerificationResult,
+  VerifiedOperationSummary,
+} from './dto/verify.dto';
+
+const DEFAULT_TESTNET_HORIZON = 'https://horizon-testnet.stellar.org';
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_BATCH_SIZE = 10;
+
+interface CacheEntry {
+  data: StellarTxVerificationResult;
+  expiresAt: number;
+}
+
+/**
+ * Public, read-only Stellar transaction verification. NexaFX linkage lookup
+ * is a stubbed hook (`nexafxReferences`) until the BlockchainOperation
+ * ledger from issue #105 exists — kept as a small in-memory map rather than
+ * a real join, per the "keep it small" scope for this scaffold.
+ */
+@Injectable()
+export class VerifyService {
+  private readonly server: Horizon.Server;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly nexafxReferences = new Map<string, string>();
+
+  constructor(configService: ConfigService) {
+    const horizonUrl =
+      configService.get<string>('STELLAR_HORIZON_URL') ?? DEFAULT_TESTNET_HORIZON;
+    this.server = new Horizon.Server(horizonUrl);
+  }
+
+  async verify(txHash: string): Promise<StellarTxVerificationResult> {
+    const cached = this.cache.get(txHash);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.data;
+    }
+
+    let record: Horizon.ServerApi.TransactionRecord;
+    try {
+      record = await this.server.transactions().transaction(txHash).call();
+    } catch {
+      throw new NotFoundException(`Stellar transaction ${txHash} not found`);
+    }
+
+    const opsPage = await this.server.operations().forTransaction(txHash).call();
+    const operations = opsPage.records.map((op) => this.summariseOperation(op));
+
+    const nexafxReference = this.nexafxReferences.get(txHash) ?? null;
+
+    const result: StellarTxVerificationResult = {
+      hash: record.hash,
+      status: record.successful ? 'SUCCESS' : 'FAILED',
+      timestamp: record.created_at,
+      fee: `${(Number(record.fee_charged) / 10_000_000).toFixed(7)} XLM`,
+      ledger: record.ledger_attr,
+      operations,
+      summary: operations[0]?.summary ?? 'Stellar transaction',
+      nexafxLinked: nexafxReference !== null,
+      nexafxReference,
+      explorerUrl: `https://stellar.expert/explorer/testnet/tx/${txHash}`,
+    };
+
+    this.cache.set(txHash, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+    return result;
+  }
+
+  async verifyBatch(hashes: string[]): Promise<StellarTxVerificationResult[]> {
+    const limited = hashes.slice(0, MAX_BATCH_SIZE);
+    return Promise.all(limited.map((hash) => this.verify(hash)));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private summariseOperation(op: any): VerifiedOperationSummary {
+    switch (op.type) {
+      case 'payment':
+        return {
+          type: 'Payment',
+          summary: `${op.amount} ${op.asset_type === 'native' ? 'XLM' : op.asset_code} sent from ${op.from} to ${op.to}`,
+        };
+      case 'change_trust':
+        return {
+          type: 'Change Trust',
+          summary: `Established trustline for ${op.asset_code ?? op.line?.asset_code ?? 'asset'} from ${op.trustor ?? op.source_account}`,
+        };
+      case 'manage_sell_offer':
+      case 'manage_buy_offer':
+        return {
+          type: 'Manage Offer',
+          summary: `Created offer to sell ${op.amount} ${op.selling?.asset_code ?? 'XLM'} for ${op.buying?.asset_code ?? 'asset'}`,
+        };
+      case 'liquidity_pool_deposit':
+        return {
+          type: 'Liquidity Pool Deposit',
+          summary: `Deposited liquidity into pool ${op.liquidity_pool_id}`,
+        };
+      default:
+        return { type: op.type, summary: `${op.type} operation` };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Small, self-contained scaffolds for four v2 issues — in-memory rather than DB-backed, to keep each one simple:

- **`src/modules/fraud-patterns`** (#704) — admin-defined fraud detection patterns with a field/op/value condition evaluator, `POST /admin/fraud-patterns/test` dry-run endpoint, and 5 seeded default patterns.
- **`src/modules/kyc-ocr`** (#701) — `OcrProvider` abstraction with a `MockOcrProvider` (used by default) and a `GoogleVisionOcrProvider` stub gated behind `OCR_PROVIDER=google` and `GOOGLE_VISION_API_KEY`; flags likely-expired documents and document-number discrepancies.
- **`src/modules/verify`** (#699) — public `GET /v2/verify/stellar/:txHash` and `POST /v2/verify/stellar/batch` (max 10) endpoints, human-readable per-operation summaries (Payment, Change Trust, Manage Offer, Liquidity Pool Deposit), 5-minute in-memory cache.
- **`src/modules/shared-reports`** (#695) — `POST /v2/shared-reports` to generate a share link, `GET /v2/public/reports/:shareToken` public anonymised view with view-count tracking and expiry (410 Gone), and HMAC-based `POST /v2/public/reports/verify`.

None of these modules are wired into `AppModule` yet — matching the existing pattern in this repo for other v2 scaffolds (e.g. `balance-alerts`).

Closes #704
Closes #701
Closes #699
Closes #695