### PR TITLE
feat(v2): scaffold entities for financial insights and testnet faucet

### DIFF
--- a/src/modules/financial-insights/entities/financial-insight.entity.ts
+++ b/src/modules/financial-insights/entities/financial-insight.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export interface InsightItem {
+  title: string;
+  body: string;
+  type: string;
+  deepLink?: string;
+}
+
+@Entity('financial_insights')
+@Index(['userId', 'weekOf'], { unique: true })
+export class FinancialInsight {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'date' })
+  weekOf: string;
+
+  @Column({ type: 'jsonb', default: () => "'[]'" })
+  insights: InsightItem[];
+
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
+  insightTypes: string[];
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  generatedAt: Date;
+}

--- a/src/modules/testnet-faucet/entities/faucet-request.entity.ts
+++ b/src/modules/testnet-faucet/entities/faucet-request.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum FaucetRequestStatus {
+  PROCESSING = 'PROCESSING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+}
+
+@Entity('faucet_requests')
+@Index(['stellarPublicKey', 'createdAt'])
+export class FaucetRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  requestedBy: string | null;
+
+  @Column({ type: 'varchar', length: 56 })
+  stellarPublicKey: string;
+
+  @Column({ type: 'numeric', precision: 20, scale: 8 })
+  amountXlm: string;
+
+  @Column({
+    type: 'enum',
+    enum: FaucetRequestStatus,
+    default: FaucetRequestStatus.PROCESSING,
+  })
+  status: FaucetRequestStatus;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  txHash: string | null;
+
+  @Column({ type: 'varchar', length: 45 })
+  ipAddress: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  apiKeyId: string | null;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+}


### PR DESCRIPTION
Scaffolds the core data model for two v2 feature modules, based at `v2`. Each change adds the primary TypeORM entity for its module, following the existing entity conventions, as a small first step toward the full feature.

- **Personalised financial insights** (#707): `FinancialInsight` entity — `weekOf` with a unique `(userId, weekOf)` index, `insights` jsonb array (typed `InsightItem`), and `insightTypes` string array.
- **Stellar testnet faucet** (#706): `FaucetRequest` entity with the `FaucetRequestStatus` enum, Stellar public key, amount, tx hash, IP/API-key attribution, and a `(stellarPublicKey, createdAt)` index to support rate limiting.

## Closes

- closes #707
- closes #706
