### PR TITLE
feat(webhooks): add payload schema versioning with v1.0 back-compat

### DIFF
--- a/docs/webhook-schema-versions.md
+++ b/docs/webhook-schema-versions.md
@@ -1,0 +1,303 @@
+# Webhook Schema Versions
+
+Every webhook NexaFX delivers carries a `schemaVersion` field. A breaking change to
+a payload's shape introduces a **new** version — an already-published version is
+never modified in place. At least two versions are deliverable at all times, and
+a deprecated version stays deliverable for **at least 90 days** after it is
+marked deprecated.
+
+```json
+{
+  "id": "6f1a6d0c-6f4e-4a37-9e19-0f9a7c1b2d34",
+  "event": "transaction.completed",
+  "schemaVersion": "2.0",
+  "data": { "...": "shape depends on schemaVersion" },
+  "timestamp": "2026-07-29T10:15:30.000Z"
+}
+```
+
+The envelope (`id`, `event`, `schemaVersion`, `data`, `timestamp`) is stable
+across versions. Only `data` changes shape.
+
+`id` identifies the **event**, not the delivery. If you register several
+endpoints for the same event — even on different schema versions — they all
+receive the same `id`, so you can deduplicate and correlate across them.
+
+---
+
+## Version registry
+
+| Version | Effective from | Deprecated on | Sunset (deliveries stop) | Status         |
+| ------- | -------------- | ------------- | ------------------------ | -------------- |
+| `1.0`   | 2025-01-15     | 2026-07-29    | 2026-10-27               | **Deprecated** |
+| `2.0`   | 2026-07-29     | —             | —                        | **Current**    |
+
+Machine-readable version of this table:
+
+```
+GET /v2/webhooks/schema-versions
+```
+
+```json
+[
+  {
+    "version": "1.0",
+    "effectiveFrom": "2025-01-15",
+    "deprecatedOn": "2026-07-29",
+    "sunsetOn": "2026-10-27"
+  },
+  {
+    "version": "2.0",
+    "effectiveFrom": "2026-07-29",
+    "deprecatedOn": null,
+    "sunsetOn": null
+  }
+]
+```
+
+---
+
+## Pinning an endpoint to a version
+
+Each endpoint carries a `preferredSchemaVersion`. Deliveries to that endpoint are
+shaped for that version.
+
+- Endpoints created **before 2026-07-29** were backfilled to `1.0`, so their
+  payload shape did not change underneath them.
+- Endpoints created **on or after 2026-07-29** default to `2.0`.
+
+Change it at any time — the switch takes effect on the next event, and no
+redeploy or re-registration is needed:
+
+```
+PATCH /v2/webhooks/:id
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{ "preferredSchemaVersion": "2.0" }
+```
+
+`preferredSchemaVersion` must be one of `1.0` or `2.0`; anything else is rejected
+with `400 Bad Request`. You can also set it at creation time:
+
+```
+POST /v2/webhooks
+
+{
+  "url": "https://example.com/hooks/nexafx",
+  "events": ["transaction.completed"],
+  "preferredSchemaVersion": "2.0"
+}
+```
+
+Roll-out tip: register a **second** endpoint pinned to `2.0` alongside your
+existing `1.0` one, verify the new shape against real traffic, then delete the
+`1.0` endpoint. Both endpoints receive the same event `id`, so you can prove the
+two shapes describe the same event before cutting over.
+
+---
+
+## Delivery headers
+
+| Header                          | Sent when            | Value                                                   |
+| ------------------------------- | -------------------- | ------------------------------------------------------- |
+| `X-NexaFX-Schema-Version`       | always               | `1.0` \| `2.0`                                          |
+| `X-NexaFX-Signature`            | always               | `sha256=<hmac of the raw request body>`                 |
+| `X-NexaFX-Schema-Deprecated`    | deprecated versions  | `true`                                                  |
+| `Deprecation`                   | deprecated versions  | `true` (RFC 8594)                                       |
+| `Sunset`                        | deprecated versions  | HTTP-date, e.g. `Tue, 27 Oct 2026 00:00:00 GMT`         |
+| `Link`                          | deprecated versions  | `<…/webhooks/schema-versions>; rel="deprecation"`       |
+
+Every delivery on a deprecated version also writes a
+`webhook.deprecated_schema_used` audit event against the endpoint, so support can
+see which integrations still need to migrate.
+
+Assert on `X-NexaFX-Schema-Version` in your handler rather than inferring the
+shape from the fields present — it makes an unexpected version a loud failure
+instead of silently-null data.
+
+---
+
+## What changed in 2.0
+
+`2.0` affects the `transaction.completed` and `transaction.failed` payloads. All
+other events (`kyc.approved`, `kyc.rejected`, `kyc.resubmission_required`,
+`rate_alert.triggered`, `referral.rewarded`, `ping`) have an unchanged `data`
+shape on both versions — only the envelope's `schemaVersion` differs.
+
+### `transaction.completed` / `transaction.failed`
+
+**v1.0** serialised the internal transaction record verbatim. Decimals arrived as
+strings, enums kept their uppercase database casing, and every column on the
+record — including internal bookkeeping fields — ended up on the wire.
+
+```json
+{
+  "id": "b23f...",
+  "userId": "9a71...",
+  "type": "SWAP",
+  "status": "SUCCESS",
+  "amount": "150.00000000",
+  "currency": "USD",
+  "rate": "1550.25000000",
+  "feeAmount": "1.50000000",
+  "feeCurrency": "USD",
+  "toCurrency": "NGN",
+  "toAmount": "232537.50000000",
+  "txHash": "e3b0c442...",
+  "reference": "ref-9",
+  "counterpartyMemo": "invoice 42",
+  "failureReason": null,
+  "createdAt": "2026-07-01T10:00:00.000Z",
+  "updatedAt": "2026-07-01T10:05:00.000Z",
+  "userNote": "…",
+  "searchVector": "…",
+  "processingLockedBy": "…",
+  "metadata": {}
+}
+```
+
+**v2.0** is an explicitly curated payload:
+
+```json
+{
+  "transactionId": "b23f...",
+  "userId": "9a71...",
+  "type": "swap",
+  "status": "success",
+  "amount": 150,
+  "currency": "USD",
+  "fee": { "amount": 1.5, "currency": "USD" },
+  "conversion": {
+    "fromCurrency": "USD",
+    "toCurrency": "NGN",
+    "toAmount": 232537.5,
+    "rate": 1550.25
+  },
+  "memo": "invoice 42",
+  "reference": "ref-9",
+  "stellarTxHash": "e3b0c442...",
+  "failureReason": null,
+  "createdAt": "2026-07-01T10:00:00.000Z",
+  "updatedAt": "2026-07-01T10:05:00.000Z"
+}
+```
+
+### Breaking changes
+
+| # | Change                                                                                            | Why                                                                                       |
+| - | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1 | `data.id` → `data.transactionId`                                                                  | `data.id` read as the envelope's event `id` and was a recurring source of consumer bugs.  |
+| 2 | Decimals are JSON numbers, not numeric-as-string (`amount`, `rate`, `toAmount`, `fee.amount`)      | Every consumer was parsing them anyway.                                                   |
+| 3 | `feeAmount` + `feeCurrency` → nested `fee`, `null` when no fee was charged                         | Distinguishes "no fee" from "fee of zero" without a second field to check.                |
+| 4 | `rate` + `toCurrency` + `toAmount` → nested `conversion`, `null` for non-converting transactions   | Groups the fields that are only ever populated together.                                  |
+| 5 | `txHash` → `stellarTxHash`                                                                        | Names the chain the hash belongs to.                                                      |
+| 6 | `counterpartyMemo` → `memo`                                                                       | Matches the field's public name in the REST API.                                          |
+| 7 | `type` and `status` are lowercase (`SWAP` → `swap`, `SUCCESS` → `success`)                          | Consistent with event names and the rest of the v2 API.                                   |
+| 8 | Internal columns removed: `userNote`, `searchVector`, `processingLockedAt`, `processingLockedBy`, `categoryId`, `metadata`, `tags`, `confidenceScore`, `confidenceLabel`, `expectedCompletionSeconds` | Internal bookkeeping. **`userNote` is the payer's private note and should never have been delivered** — this is the main reason to migrate off `1.0`. |
+
+Fields absent from the source record arrive as `null` in v2 rather than being
+omitted, so the key set is stable.
+
+---
+
+## Migration guide: 1.0 → 2.0
+
+**1. Read `schemaVersion` before touching `data`.**
+
+```ts
+function handleWebhook(body: WebhookEnvelope) {
+  switch (body.schemaVersion) {
+    case '1.0':
+      return handleTransactionV1(body.data);
+    case '2.0':
+      return handleTransactionV2(body.data);
+    default:
+      // A version you have not deployed support for. Store and alert —
+      // do not silently drop.
+      throw new Error(`Unhandled webhook schema ${body.schemaVersion}`);
+  }
+}
+```
+
+**2. Map the fields.**
+
+| v1.0                             | v2.0                                          |
+| -------------------------------- | --------------------------------------------- |
+| `data.id`                        | `data.transactionId`                          |
+| `parseFloat(data.amount)`        | `data.amount`                                 |
+| `data.status === 'SUCCESS'`      | `data.status === 'success'`                   |
+| `data.type === 'SWAP'`           | `data.type === 'swap'`                        |
+| `parseFloat(data.feeAmount)`     | `data.fee?.amount ?? 0`                       |
+| `data.feeCurrency`               | `data.fee?.currency`                          |
+| `parseFloat(data.rate)`          | `data.conversion?.rate`                       |
+| `data.toCurrency`                | `data.conversion?.toCurrency`                 |
+| `parseFloat(data.toAmount)`      | `data.conversion?.toAmount`                   |
+| `data.txHash`                    | `data.stellarTxHash`                          |
+| `data.counterpartyMemo`          | `data.memo`                                   |
+| `data.userNote` and other internals | *not available* — fetch via the REST API if genuinely needed |
+
+**3. Deploy the v2 branch of your handler** while still pinned to `1.0`. It is
+dead code until you flip the version, so this step is safe to ship on its own.
+
+**4. Flip the endpoint.**
+
+```
+PATCH /v2/webhooks/:id   { "preferredSchemaVersion": "2.0" }
+```
+
+**5. Confirm the cutover.** `X-NexaFX-Schema-Deprecated` and `Sunset` stop
+appearing, and `X-NexaFX-Schema-Version` reads `2.0`. Use
+`GET /v2/webhooks/:id/deliveries` to inspect recent payloads.
+
+Rollback is a single `PATCH` back to `"1.0"` at any point before the sunset date.
+
+---
+
+## Deprecation timeline
+
+| Date       | What happens                                                                                                     |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| 2025-01-15 | `1.0` becomes available.                                                                                          |
+| 2026-07-29 | `2.0` becomes available and is the default for new endpoints. `1.0` is marked deprecated; existing endpoints stay on it and start receiving `Deprecation`/`Sunset` headers. The 90-day window opens. |
+| 2026-10-27 | `1.0` sunset. Endpoints still pinned to `1.0` are migrated to `2.0` and receive the v2 shape.                      |
+
+Policy for every future version:
+
+- A version is deliverable for **at least 90 days** after it is marked
+  deprecated.
+- At least **two** versions are deliverable at all times.
+- An already-published version's payload shape is **never** modified. Additive or
+  breaking, a change to `data` means a new version.
+- Adding a field to the **envelope** is additive and is not a version bump —
+  parse the envelope non-strictly.
+
+---
+
+## Implementation notes
+
+| Concern                          | Location                                                             |
+| -------------------------------- | -------------------------------------------------------------------- |
+| Version registry, deprecation metadata, headers | `src/modules/webhooks/schemas/webhook-schema-version.ts` |
+| Envelope types                   | `src/modules/webhooks/schemas/webhook-payload.types.ts`               |
+| v1.0 payload builder (frozen)    | `src/modules/webhooks/schemas/transaction-completed.v1.ts`            |
+| v2.0 payload builder             | `src/modules/webhooks/schemas/transaction-completed.v2.ts`            |
+| `WebhookSchemaTransformer`       | `src/modules/webhooks/schemas/webhook-schema.transformer.ts`          |
+| Endpoint preference column       | `src/webhooks/entities/webhook-endpoint.entity.ts`                    |
+
+### Adding version 3.0
+
+1. Add `'3.0'` to `WEBHOOK_SCHEMA_VERSIONS` and set
+   `LATEST_WEBHOOK_SCHEMA_VERSION`.
+2. Add its `WEBHOOK_SCHEMA_VERSION_REGISTRY` entry, and set `deprecatedOn` /
+   `sunsetOn` (≥ 90 days later) on the version being retired.
+3. Add `<event>.v3.ts` builders and register them in `SCHEMA_REGISTRY`. **Leave
+   the older builders untouched.**
+4. Drop the sunset version from `WEBHOOK_SCHEMA_VERSIONS` only once its sunset
+   date has passed and no endpoint is still pinned to it — keeping at least two
+   versions live.
+5. Update the tables above.
+
+Events with no entry in `SCHEMA_REGISTRY` pass `data` through unchanged on every
+version, so a new event does not need per-version builders until its shape first
+breaks.

--- a/src/migrations/1770000000000-AddWebhookSchemaVersion.ts
+++ b/src/migrations/1770000000000-AddWebhookSchemaVersion.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds WebhookEndpoint.preferredSchemaVersion.
+ *
+ * Endpoints that already exist are backfilled to '1.0' — they were registered
+ * against the v1 payload shape, so silently promoting them to v2 would be a
+ * breaking change. New endpoints pick up the '2.0' column default.
+ */
+export class AddWebhookSchemaVersion1770000000000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const rows = (await queryRunner.query(
+      `SELECT to_regclass('public.webhook_endpoints') IS NOT NULL AS present`,
+    )) as Array<{ present: boolean }>;
+    if (!rows[0]?.present) return;
+
+    await queryRunner.query(`
+      ALTER TABLE "webhook_endpoints"
+        ADD COLUMN IF NOT EXISTS "preferredSchemaVersion" varchar(10);
+    `);
+
+    await queryRunner.query(`
+      UPDATE "webhook_endpoints"
+        SET "preferredSchemaVersion" = '1.0'
+        WHERE "preferredSchemaVersion" IS NULL;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "webhook_endpoints"
+        ALTER COLUMN "preferredSchemaVersion" SET DEFAULT '2.0';
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "webhook_endpoints"
+        ALTER COLUMN "preferredSchemaVersion" SET NOT NULL;
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE IF EXISTS "webhook_endpoints"
+        DROP COLUMN IF EXISTS "preferredSchemaVersion";
+    `);
+  }
+}

--- a/src/modules/webhooks/schemas/index.ts
+++ b/src/modules/webhooks/schemas/index.ts
@@ -1,0 +1,5 @@
+export * from './webhook-payload.types';
+export * from './webhook-schema-version';
+export * from './webhook-schema.transformer';
+export * from './transaction-completed.v1';
+export * from './transaction-completed.v2';

--- a/src/modules/webhooks/schemas/transaction-completed.v1.ts
+++ b/src/modules/webhooks/schemas/transaction-completed.v1.ts
@@ -1,0 +1,47 @@
+import { WebhookPayloadBuilder } from './webhook-payload.types';
+
+/**
+ * `transaction.completed` / `transaction.failed` — schema v1.0. FROZEN.
+ *
+ * v1 serialises the Transaction entity verbatim: every column the entity carries
+ * lands on the wire, Postgres numerics arrive as strings, and enums keep their
+ * uppercase database casing.
+ *
+ * Do not change this shape. Consumers still pinned to 1.0 depend on it field for
+ * field — additions, removals and renames all belong in a new version. See
+ * transaction-completed.v2.ts for the curated replacement.
+ */
+export interface TransactionCompletedV1Data {
+  id: string;
+  userId: string;
+  /** Uppercase enum, e.g. 'SWAP'. */
+  type: string;
+  /** Uppercase enum, e.g. 'SUCCESS'. */
+  status: string;
+  /** Postgres numeric, serialised as a string — e.g. '150.00000000'. */
+  amount: string;
+  currency: string;
+  rate?: string | null;
+  feeAmount?: string | null;
+  feeCurrency?: string | null;
+  toCurrency?: string | null;
+  toAmount?: string | null;
+  txHash?: string | null;
+  reference?: string | null;
+  counterpartyMemo?: string | null;
+  failureReason?: string | null;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
+  /** v1 emitted every remaining entity column, internal ones included. */
+  [key: string]: unknown;
+}
+
+export const buildTransactionCompletedV1: WebhookPayloadBuilder<
+  unknown,
+  TransactionCompletedV1Data
+> = (data) =>
+  // Shallow copy only. v1 is a frozen pass-through of the entity, but the stored
+  // delivery payload must not alias the caller's object.
+  ({
+    ...((data ?? {}) as Record<string, unknown>),
+  }) as unknown as TransactionCompletedV1Data;

--- a/src/modules/webhooks/schemas/transaction-completed.v2.ts
+++ b/src/modules/webhooks/schemas/transaction-completed.v2.ts
@@ -1,0 +1,135 @@
+import { WebhookPayloadBuilder } from './webhook-payload.types';
+
+/**
+ * `transaction.completed` / `transaction.failed` — schema v2.0 (current).
+ *
+ * Breaking changes from v1.0:
+ *  - `id` renamed to `transactionId` (v1's `id` collided with the envelope id).
+ *  - Decimal fields are JSON numbers, no longer numeric-as-string.
+ *  - `feeAmount`/`feeCurrency` collapsed into a nested `fee` object, null when
+ *    no fee was charged.
+ *  - `rate`/`toCurrency`/`toAmount` collapsed into a nested `conversion` object,
+ *    null for non-converting transactions.
+ *  - `txHash` renamed to `stellarTxHash`.
+ *  - `counterpartyMemo` renamed to `memo`.
+ *  - `type`/`status` are lowercase.
+ *  - Internal and private columns are no longer emitted — notably `userNote`,
+ *    the transaction owner's private note, which v1 leaked to every subscriber.
+ */
+
+export interface TransactionCompletedV2Fee {
+  amount: number;
+  currency: string | null;
+}
+
+export interface TransactionCompletedV2Conversion {
+  fromCurrency: string | null;
+  toCurrency: string;
+  toAmount: number | null;
+  rate: number | null;
+}
+
+export interface TransactionCompletedV2Data {
+  transactionId: string | null;
+  userId: string | null;
+  /** Lowercase, e.g. 'swap'. */
+  type: string | null;
+  /** Lowercase, e.g. 'success'. */
+  status: string | null;
+  amount: number | null;
+  currency: string | null;
+  fee: TransactionCompletedV2Fee | null;
+  conversion: TransactionCompletedV2Conversion | null;
+  memo: string | null;
+  reference: string | null;
+  stellarTxHash: string | null;
+  failureReason: string | null;
+  /** ISO 8601. */
+  createdAt: string | null;
+  /** ISO 8601. */
+  updatedAt: string | null;
+}
+
+/**
+ * The transaction record as it reaches the builder — a TypeORM entity, a partial
+ * of one, or a plain object from a replayed delivery. Every field is `unknown` so
+ * the coercion helpers below are the only way to read one.
+ */
+interface TransactionSource {
+  id?: unknown;
+  userId?: unknown;
+  type?: unknown;
+  status?: unknown;
+  amount?: unknown;
+  currency?: unknown;
+  rate?: unknown;
+  feeAmount?: unknown;
+  feeCurrency?: unknown;
+  toCurrency?: unknown;
+  toAmount?: unknown;
+  txHash?: unknown;
+  stellarTxHash?: unknown;
+  reference?: unknown;
+  counterpartyMemo?: unknown;
+  failureReason?: unknown;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toIsoString(value: unknown): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value as string);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function toLowerCase(value: unknown): string | null {
+  return typeof value === 'string' ? value.toLowerCase() : null;
+}
+
+function toText(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+export const buildTransactionCompletedV2: WebhookPayloadBuilder<
+  unknown,
+  TransactionCompletedV2Data
+> = (data) => {
+  const tx = (data ?? {}) as TransactionSource;
+
+  const feeAmount = toNumber(tx.feeAmount);
+  const currency = toText(tx.currency);
+  const toCurrency = toText(tx.toCurrency);
+
+  return {
+    transactionId: toText(tx.id),
+    userId: toText(tx.userId),
+    type: toLowerCase(tx.type),
+    status: toLowerCase(tx.status),
+    amount: toNumber(tx.amount),
+    currency,
+    fee:
+      feeAmount === null
+        ? null
+        : { amount: feeAmount, currency: toText(tx.feeCurrency) ?? currency },
+    conversion: toCurrency
+      ? {
+          fromCurrency: currency,
+          toCurrency,
+          toAmount: toNumber(tx.toAmount),
+          rate: toNumber(tx.rate),
+        }
+      : null,
+    memo: toText(tx.counterpartyMemo),
+    reference: toText(tx.reference),
+    stellarTxHash: toText(tx.stellarTxHash) ?? toText(tx.txHash),
+    failureReason: toText(tx.failureReason),
+    createdAt: toIsoString(tx.createdAt),
+    updatedAt: toIsoString(tx.updatedAt),
+  };
+};

--- a/src/modules/webhooks/schemas/webhook-payload.types.ts
+++ b/src/modules/webhooks/schemas/webhook-payload.types.ts
@@ -1,0 +1,29 @@
+import { WebhookSchemaVersion } from './webhook-schema-version';
+
+/**
+ * The envelope wrapping every webhook delivery. Stable across schema versions —
+ * only `data` changes shape between versions.
+ */
+export interface WebhookEnvelope<TData = unknown> {
+  /** Event id, stable across every endpoint that receives this event. */
+  id: string;
+  event: string;
+  schemaVersion: WebhookSchemaVersion;
+  data: TData;
+  /** ISO 8601 timestamp of when the event was dispatched. */
+  timestamp: string;
+}
+
+/**
+ * Lets the dispatcher reuse one id/timestamp across the fan-out so the same
+ * event is correlatable even when endpoints receive different payload shapes.
+ */
+export interface WebhookEnvelopeOptions {
+  id?: string;
+  timestamp?: string;
+}
+
+/** Shapes an event's raw source data into one version's `data` payload. */
+export type WebhookPayloadBuilder<TIn = any, TOut = unknown> = (
+  data: TIn,
+) => TOut;

--- a/src/modules/webhooks/schemas/webhook-schema-version.ts
+++ b/src/modules/webhooks/schemas/webhook-schema-version.ts
@@ -1,0 +1,126 @@
+/**
+ * Webhook payload schema versioning.
+ *
+ * Every envelope NexaFX delivers carries a `schemaVersion`. A breaking change to
+ * a payload's shape introduces a NEW version — an already-published version's
+ * shape is never modified. At least two versions stay deliverable at all times,
+ * and a version remains deliverable for at least DEPRECATION_WINDOW_DAYS after
+ * it is marked deprecated.
+ *
+ * Consumer-facing migration guide: docs/webhook-schema-versions.md
+ */
+
+export const WEBHOOK_SCHEMA_VERSIONS = ['1.0', '2.0'] as const;
+
+export type WebhookSchemaVersion = (typeof WEBHOOK_SCHEMA_VERSIONS)[number];
+
+export const LATEST_WEBHOOK_SCHEMA_VERSION: WebhookSchemaVersion = '2.0';
+
+/**
+ * Applied to endpoints created from now on. Endpoints that existed before
+ * versioning shipped are backfilled to '1.0' by the migration so their payload
+ * shape does not change underneath them.
+ */
+export const DEFAULT_WEBHOOK_SCHEMA_VERSION = LATEST_WEBHOOK_SCHEMA_VERSION;
+
+/** Minimum time a deprecated version stays deliverable before sunset. */
+export const DEPRECATION_WINDOW_DAYS = 90;
+
+export const SCHEMA_VERSIONS_DOC_URL =
+  'https://docs.nexafx.com/webhooks/schema-versions';
+
+export interface WebhookSchemaVersionInfo {
+  version: WebhookSchemaVersion;
+  /** ISO date the version became deliverable. */
+  effectiveFrom: string;
+  /** ISO date the version was marked deprecated, or null while current. */
+  deprecatedOn: string | null;
+  /**
+   * ISO date deliveries on this version stop, or null while current.
+   * Always at least DEPRECATION_WINDOW_DAYS after `deprecatedOn`.
+   */
+  sunsetOn: string | null;
+}
+
+export const WEBHOOK_SCHEMA_VERSION_REGISTRY: Record<
+  WebhookSchemaVersion,
+  WebhookSchemaVersionInfo
+> = {
+  '1.0': {
+    version: '1.0',
+    effectiveFrom: '2025-01-15',
+    deprecatedOn: '2026-07-29',
+    sunsetOn: '2026-10-27', // deprecatedOn + 90 days
+  },
+  '2.0': {
+    version: '2.0',
+    effectiveFrom: '2026-07-29',
+    deprecatedOn: null,
+    sunsetOn: null,
+  },
+};
+
+export function isSupportedSchemaVersion(
+  value: unknown,
+): value is WebhookSchemaVersion {
+  return (
+    typeof value === 'string' &&
+    (WEBHOOK_SCHEMA_VERSIONS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Coerce a stored/user-supplied value to a deliverable version.
+ *
+ * Delivery must never fail because a row holds an unrecognised value, so
+ * anything unsupported resolves to the latest version. API input is validated
+ * up front by UpdateWebhookEndpointDto.
+ */
+export function resolveSchemaVersion(value: unknown): WebhookSchemaVersion {
+  return isSupportedSchemaVersion(value)
+    ? value
+    : LATEST_WEBHOOK_SCHEMA_VERSION;
+}
+
+export function getSchemaVersionInfo(
+  version: WebhookSchemaVersion,
+): WebhookSchemaVersionInfo {
+  return WEBHOOK_SCHEMA_VERSION_REGISTRY[version];
+}
+
+export function isDeprecatedSchemaVersion(version: unknown): boolean {
+  return (
+    isSupportedSchemaVersion(version) &&
+    WEBHOOK_SCHEMA_VERSION_REGISTRY[version].deprecatedOn !== null
+  );
+}
+
+/**
+ * Headers advertising the schema version a delivery was shaped for.
+ *
+ * Deprecated versions additionally get the RFC 8594 `Deprecation`/`Sunset`
+ * pair, a `Link` to the migration guide, and the NexaFX-specific
+ * `X-NexaFX-Schema-Deprecated` flag.
+ */
+export function buildSchemaHeaders(
+  version: WebhookSchemaVersion,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-NexaFX-Schema-Version': version,
+  };
+
+  const info = WEBHOOK_SCHEMA_VERSION_REGISTRY[version];
+  if (!info?.deprecatedOn) return headers;
+
+  headers['X-NexaFX-Schema-Deprecated'] = 'true';
+  headers['Deprecation'] = 'true';
+  headers['Link'] =
+    `<${SCHEMA_VERSIONS_DOC_URL}>; rel="deprecation"; type="text/html"`;
+
+  if (info.sunsetOn) {
+    // RFC 8594 requires an HTTP-date, not an ISO-8601 date.
+    headers['Sunset'] = new Date(`${info.sunsetOn}T00:00:00.000Z`).toUTCString();
+  }
+
+  return headers;
+}

--- a/src/modules/webhooks/schemas/webhook-schema.transformer.spec.ts
+++ b/src/modules/webhooks/schemas/webhook-schema.transformer.spec.ts
@@ -1,0 +1,372 @@
+import {
+  buildSchemaHeaders,
+  DEPRECATION_WINDOW_DAYS,
+  getSchemaVersionInfo,
+  isDeprecatedSchemaVersion,
+  LATEST_WEBHOOK_SCHEMA_VERSION,
+  WEBHOOK_SCHEMA_VERSION_REGISTRY,
+  WEBHOOK_SCHEMA_VERSIONS,
+  WebhookSchemaTransformer,
+} from './index';
+
+const RAW_TRANSACTION = {
+  id: 'tx-123',
+  userId: 'user-1',
+  type: 'SWAP',
+  status: 'SUCCESS',
+  amount: '150.00000000',
+  currency: 'USD',
+  rate: '1550.25000000',
+  feeAmount: '1.50000000',
+  feeCurrency: 'USD',
+  toCurrency: 'NGN',
+  toAmount: '232537.50000000',
+  txHash: 'hash-abc',
+  reference: 'ref-9',
+  counterpartyMemo: 'invoice 42',
+  failureReason: null,
+  createdAt: new Date('2026-07-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-07-01T10:05:00.000Z'),
+  // Internal / private columns that v1 leaked and v2 must not emit.
+  userNote: 'private note',
+  searchVector: "'swap':1",
+  processingLockedBy: 'worker-3',
+  metadata: { internal: true },
+};
+
+describe('WebhookSchemaTransformer', () => {
+  describe('envelope', () => {
+    it('stamps the resolved schemaVersion on the envelope', () => {
+      const v1 = WebhookSchemaTransformer.transform(
+        'transaction.completed',
+        RAW_TRANSACTION,
+        '1.0',
+      );
+      const v2 = WebhookSchemaTransformer.transform(
+        'transaction.completed',
+        RAW_TRANSACTION,
+        '2.0',
+      );
+
+      expect(v1.schemaVersion).toBe('1.0');
+      expect(v2.schemaVersion).toBe('2.0');
+    });
+
+    it('emits the full envelope contract', () => {
+      const envelope = WebhookSchemaTransformer.transform(
+        'transaction.completed',
+        RAW_TRANSACTION,
+        '2.0',
+      );
+
+      expect(Object.keys(envelope)).toEqual([
+        'id',
+        'event',
+        'schemaVersion',
+        'data',
+        'timestamp',
+      ]);
+      expect(envelope.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(envelope.event).toBe('transaction.completed');
+      expect(new Date(envelope.timestamp).toISOString()).toBe(
+        envelope.timestamp,
+      );
+    });
+
+    it('reuses a caller-supplied id and timestamp across the fan-out', () => {
+      const options = { id: 'event-1', timestamp: '2026-07-29T00:00:00.000Z' };
+
+      const v1 = WebhookSchemaTransformer.transform(
+        'transaction.completed',
+        RAW_TRANSACTION,
+        '1.0',
+        options,
+      );
+      const v2 = WebhookSchemaTransformer.transform(
+        'transaction.completed',
+        RAW_TRANSACTION,
+        '2.0',
+        options,
+      );
+
+      expect(v1.id).toBe('event-1');
+      expect(v2.id).toBe('event-1');
+      expect(v1.timestamp).toBe(options.timestamp);
+      expect(v2.timestamp).toBe(options.timestamp);
+    });
+
+    it('falls back to the latest version for unsupported input', () => {
+      expect(
+        WebhookSchemaTransformer.transform('transaction.completed', {}, '9.9')
+          .schemaVersion,
+      ).toBe(LATEST_WEBHOOK_SCHEMA_VERSION);
+      expect(
+        WebhookSchemaTransformer.transform('transaction.completed', {}, null)
+          .schemaVersion,
+      ).toBe(LATEST_WEBHOOK_SCHEMA_VERSION);
+    });
+  });
+
+  describe('transaction.completed v1.0', () => {
+    it('preserves the historical entity-dump shape', () => {
+      const { data } = WebhookSchemaTransformer.transform<
+        Record<string, unknown>
+      >('transaction.completed', RAW_TRANSACTION, '1.0');
+
+      expect(data).toEqual(RAW_TRANSACTION);
+      expect(data.amount).toBe('150.00000000');
+      expect(data.type).toBe('SWAP');
+      expect(data.status).toBe('SUCCESS');
+      expect(data.feeAmount).toBe('1.50000000');
+      expect(data.txHash).toBe('hash-abc');
+    });
+
+    it('does not alias the source object', () => {
+      const source = { ...RAW_TRANSACTION };
+      const { data } = WebhookSchemaTransformer.transform<
+        Record<string, unknown>
+      >('transaction.completed', source, '1.0');
+
+      expect(data).not.toBe(source);
+      (data as any).amount = 'mutated';
+      expect(source.amount).toBe('150.00000000');
+    });
+
+    it('tolerates null data', () => {
+      const { data } = WebhookSchemaTransformer.transform(
+        'transaction.completed',
+        null,
+        '1.0',
+      );
+      expect(data).toEqual({});
+    });
+  });
+
+  describe('transaction.completed v2.0', () => {
+    it('emits the curated v2 shape', () => {
+      const { data } = WebhookSchemaTransformer.transform(
+        'transaction.completed',
+        RAW_TRANSACTION,
+        '2.0',
+      );
+
+      expect(data).toEqual({
+        transactionId: 'tx-123',
+        userId: 'user-1',
+        type: 'swap',
+        status: 'success',
+        amount: 150,
+        currency: 'USD',
+        fee: { amount: 1.5, currency: 'USD' },
+        conversion: {
+          fromCurrency: 'USD',
+          toCurrency: 'NGN',
+          toAmount: 232537.5,
+          rate: 1550.25,
+        },
+        memo: 'invoice 42',
+        reference: 'ref-9',
+        stellarTxHash: 'hash-abc',
+        failureReason: null,
+        createdAt: '2026-07-01T10:00:00.000Z',
+        updatedAt: '2026-07-01T10:05:00.000Z',
+      });
+    });
+
+    it('drops internal and private columns that v1 leaked', () => {
+      const { data } = WebhookSchemaTransformer.transform<
+        Record<string, unknown>
+      >('transaction.completed', RAW_TRANSACTION, '2.0');
+
+      expect(data).not.toHaveProperty('userNote');
+      expect(data).not.toHaveProperty('searchVector');
+      expect(data).not.toHaveProperty('processingLockedBy');
+      expect(data).not.toHaveProperty('metadata');
+      // Renamed, so the v1 keys must be gone too.
+      expect(data).not.toHaveProperty('id');
+      expect(data).not.toHaveProperty('txHash');
+      expect(data).not.toHaveProperty('feeAmount');
+      expect(data).not.toHaveProperty('counterpartyMemo');
+    });
+
+    it('nulls the fee and conversion objects when they do not apply', () => {
+      const { data } = WebhookSchemaTransformer.transform<any>(
+        'transaction.completed',
+        {
+          id: 'tx-9',
+          userId: 'user-1',
+          type: 'DEPOSIT',
+          status: 'PENDING',
+          amount: '10.5',
+          currency: 'USD',
+          feeAmount: null,
+          toCurrency: null,
+        },
+        '2.0',
+      );
+
+      expect(data.fee).toBeNull();
+      expect(data.conversion).toBeNull();
+      expect(data.amount).toBe(10.5);
+    });
+
+    it('falls back to the entity currency when no fee currency is set', () => {
+      const { data } = WebhookSchemaTransformer.transform<any>(
+        'transaction.completed',
+        { currency: 'EUR', feeAmount: '0.25', feeCurrency: null },
+        '2.0',
+      );
+
+      expect(data.fee).toEqual({ amount: 0.25, currency: 'EUR' });
+    });
+
+    it('prefers stellarTxHash over the legacy txHash column', () => {
+      const { data } = WebhookSchemaTransformer.transform<any>(
+        'transaction.completed',
+        { stellarTxHash: 'stellar-1', txHash: 'legacy-1' },
+        '2.0',
+      );
+
+      expect(data.stellarTxHash).toBe('stellar-1');
+    });
+
+    it('nulls unparseable numbers and dates instead of emitting NaN', () => {
+      const { data } = WebhookSchemaTransformer.transform<any>(
+        'transaction.completed',
+        { amount: 'not-a-number', createdAt: 'not-a-date' },
+        '2.0',
+      );
+
+      expect(data.amount).toBeNull();
+      expect(data.createdAt).toBeNull();
+    });
+
+    it('tolerates null data', () => {
+      const { data } = WebhookSchemaTransformer.transform<any>(
+        'transaction.completed',
+        null,
+        '2.0',
+      );
+      expect(data.transactionId).toBeNull();
+      expect(data.fee).toBeNull();
+    });
+  });
+
+  describe('transaction.failed', () => {
+    it('shares the transaction builders with transaction.completed', () => {
+      const failed = {
+        ...RAW_TRANSACTION,
+        status: 'FAILED',
+        failureReason: 'insufficient balance',
+      };
+
+      const v1 = WebhookSchemaTransformer.transform<any>(
+        'transaction.failed',
+        failed,
+        '1.0',
+      );
+      const v2 = WebhookSchemaTransformer.transform<any>(
+        'transaction.failed',
+        failed,
+        '2.0',
+      );
+
+      expect(v1.data.status).toBe('FAILED');
+      expect(v2.data.status).toBe('failed');
+      expect(v2.data.failureReason).toBe('insufficient balance');
+    });
+  });
+
+  describe('events without a versioned schema', () => {
+    it('passes data through unchanged on every version', () => {
+      const data = { message: 'Test ping from NexaFX' };
+
+      for (const version of WEBHOOK_SCHEMA_VERSIONS) {
+        const envelope = WebhookSchemaTransformer.transform(
+          'ping',
+          data,
+          version,
+        );
+        expect(envelope.data).toEqual(data);
+        expect(envelope.schemaVersion).toBe(version);
+      }
+    });
+
+    it('reports which events have versioned schemas', () => {
+      expect(
+        WebhookSchemaTransformer.hasVersionedSchema('transaction.completed'),
+      ).toBe(true);
+      expect(WebhookSchemaTransformer.hasVersionedSchema('ping')).toBe(false);
+      expect(WebhookSchemaTransformer.registeredEvents()).toEqual(
+        expect.arrayContaining(['transaction.completed', 'transaction.failed']),
+      );
+    });
+  });
+
+  describe('version support', () => {
+    it('accepts only registered versions', () => {
+      expect(WebhookSchemaTransformer.isSupportedVersion('1.0')).toBe(true);
+      expect(WebhookSchemaTransformer.isSupportedVersion('2.0')).toBe(true);
+      expect(WebhookSchemaTransformer.isSupportedVersion('3.0')).toBe(false);
+      expect(WebhookSchemaTransformer.isSupportedVersion(2.0)).toBe(false);
+      expect(WebhookSchemaTransformer.isSupportedVersion(undefined)).toBe(false);
+    });
+
+    it('keeps at least two versions deliverable', () => {
+      expect(WEBHOOK_SCHEMA_VERSIONS.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});
+
+describe('schema deprecation metadata', () => {
+  it('marks 1.0 deprecated and 2.0 current', () => {
+    expect(isDeprecatedSchemaVersion('1.0')).toBe(true);
+    expect(isDeprecatedSchemaVersion('2.0')).toBe(false);
+    expect(isDeprecatedSchemaVersion('9.9')).toBe(false);
+  });
+
+  it('gives every deprecated version at least a 90-day sunset window', () => {
+    for (const info of Object.values(WEBHOOK_SCHEMA_VERSION_REGISTRY)) {
+      if (!info.deprecatedOn) continue;
+
+      expect(info.sunsetOn).not.toBeNull();
+      const windowDays =
+        (new Date(info.sunsetOn as string).getTime() -
+          new Date(info.deprecatedOn).getTime()) /
+        86_400_000;
+      expect(windowDays).toBeGreaterThanOrEqual(DEPRECATION_WINDOW_DAYS);
+    }
+  });
+
+  it('records an effective date for every version', () => {
+    for (const version of WEBHOOK_SCHEMA_VERSIONS) {
+      const info = getSchemaVersionInfo(version);
+      expect(info.version).toBe(version);
+      expect(Number.isNaN(new Date(info.effectiveFrom).getTime())).toBe(false);
+    }
+  });
+});
+
+describe('buildSchemaHeaders', () => {
+  it('advertises the version without deprecation flags on 2.0', () => {
+    expect(buildSchemaHeaders('2.0')).toEqual({
+      'X-NexaFX-Schema-Version': '2.0',
+    });
+  });
+
+  it('adds deprecation and sunset headers on 1.0', () => {
+    const headers = buildSchemaHeaders('1.0');
+
+    expect(headers['X-NexaFX-Schema-Version']).toBe('1.0');
+    expect(headers['X-NexaFX-Schema-Deprecated']).toBe('true');
+    expect(headers['Deprecation']).toBe('true');
+    expect(headers['Link']).toContain('rel="deprecation"');
+    // RFC 8594 requires an HTTP-date, not ISO-8601.
+    expect(headers['Sunset']).toBe(
+      new Date(
+        `${WEBHOOK_SCHEMA_VERSION_REGISTRY['1.0'].sunsetOn}T00:00:00.000Z`,
+      ).toUTCString(),
+    );
+    expect(headers['Sunset']).toMatch(/GMT$/);
+  });
+});

--- a/src/modules/webhooks/schemas/webhook-schema.transformer.ts
+++ b/src/modules/webhooks/schemas/webhook-schema.transformer.ts
@@ -1,0 +1,79 @@
+import * as crypto from 'crypto';
+import {
+  WebhookEnvelope,
+  WebhookEnvelopeOptions,
+  WebhookPayloadBuilder,
+} from './webhook-payload.types';
+import {
+  isSupportedSchemaVersion,
+  resolveSchemaVersion,
+  WebhookSchemaVersion,
+} from './webhook-schema-version';
+import { buildTransactionCompletedV1 } from './transaction-completed.v1';
+import { buildTransactionCompletedV2 } from './transaction-completed.v2';
+
+type VersionedBuilders = Partial<
+  Record<WebhookSchemaVersion, WebhookPayloadBuilder>
+>;
+
+/**
+ * Events with no registered builder are delivered with `data` untouched on every
+ * version — their shape has never changed, so there is nothing to transform.
+ */
+const passThrough: WebhookPayloadBuilder = (data) => data;
+
+const SCHEMA_REGISTRY: Record<string, VersionedBuilders> = {
+  'transaction.completed': {
+    '1.0': buildTransactionCompletedV1,
+    '2.0': buildTransactionCompletedV2,
+  },
+  // Identical payload shape to transaction.completed, so it shares the builders.
+  'transaction.failed': {
+    '1.0': buildTransactionCompletedV1,
+    '2.0': buildTransactionCompletedV2,
+  },
+};
+
+export class WebhookSchemaTransformer {
+  /**
+   * Shape an event into the envelope for a specific schema version.
+   *
+   * `version` is a plain string rather than WebhookSchemaVersion because it
+   * usually arrives from the database; unsupported values resolve to the latest
+   * version rather than failing the delivery.
+   */
+  static transform<TData = unknown>(
+    event: string,
+    data: unknown,
+    version: string | null | undefined,
+    options: WebhookEnvelopeOptions = {},
+  ): WebhookEnvelope<TData> {
+    const schemaVersion = resolveSchemaVersion(version);
+    const build = SCHEMA_REGISTRY[event]?.[schemaVersion] ?? passThrough;
+
+    return {
+      id: options.id ?? crypto.randomUUID(),
+      event,
+      schemaVersion,
+      data: build(data) as TData,
+      timestamp: options.timestamp ?? new Date().toISOString(),
+    };
+  }
+
+  static isSupportedVersion(value: unknown): value is WebhookSchemaVersion {
+    return isSupportedSchemaVersion(value);
+  }
+
+  static resolveVersion(value: unknown): WebhookSchemaVersion {
+    return resolveSchemaVersion(value);
+  }
+
+  /** True when the event has version-specific builders rather than pass-through. */
+  static hasVersionedSchema(event: string): boolean {
+    return SCHEMA_REGISTRY[event] !== undefined;
+  }
+
+  static registeredEvents(): string[] {
+    return Object.keys(SCHEMA_REGISTRY);
+  }
+}

--- a/src/webhooks/controllers/webhook.controller.spec.ts
+++ b/src/webhooks/controllers/webhook.controller.spec.ts
@@ -1,5 +1,6 @@
 import { WebhookController } from './webhook.controller';
 import { WebhookService } from '../services/webhook.service';
+import { WEBHOOK_SCHEMA_VERSIONS } from '../../modules/webhooks/schemas';
 
 describe('WebhookController', () => {
   let controller: WebhookController;
@@ -8,6 +9,7 @@ describe('WebhookController', () => {
   beforeEach(() => {
     service = {
       createEndpoint: jest.fn(),
+      updateEndpoint: jest.fn(),
       listEndpoints: jest.fn(),
       deleteEndpoint: jest.fn(),
       getDeliveryHistory: jest.fn(),
@@ -35,6 +37,58 @@ describe('WebhookController', () => {
       { id: '1', url: 'https://test.com', events: ['*'] },
     ]);
     expect((result[0] as any).secret).toBeUndefined();
+  });
+
+  it('should update the preferred schema version and omit the secret', async () => {
+    (service.updateEndpoint as jest.Mock).mockResolvedValue({
+      id: '1',
+      secret: 'hidden-secret',
+      url: 'https://test.com',
+      events: ['*'],
+      preferredSchemaVersion: '1.0',
+    });
+
+    const req = { user: { id: 'user1' } };
+    const result = await controller.update(req, '1', {
+      preferredSchemaVersion: '1.0',
+    });
+
+    expect(service.updateEndpoint).toHaveBeenCalledWith('user1', '1', {
+      preferredSchemaVersion: '1.0',
+    });
+    expect(result).toEqual({
+      id: '1',
+      url: 'https://test.com',
+      events: ['*'],
+      preferredSchemaVersion: '1.0',
+    });
+    expect((result as any).secret).toBeUndefined();
+  });
+
+  it('should expose every schema version with its sunset date', () => {
+    const versions = controller.getSchemaVersions();
+
+    expect(versions.map((v) => v.version)).toEqual([
+      ...WEBHOOK_SCHEMA_VERSIONS,
+    ]);
+    expect(versions.find((v) => v.version === '1.0')?.sunsetOn).toBeTruthy();
+    expect(versions.find((v) => v.version === '2.0')?.sunsetOn).toBeNull();
+  });
+
+  it('should forward the preferred schema version on create', async () => {
+    const req = { user: { id: 'user1' } };
+    await controller.create(req, {
+      url: 'https://test.com',
+      events: ['*'],
+      preferredSchemaVersion: '1.0',
+    });
+
+    expect(service.createEndpoint).toHaveBeenCalledWith(
+      'user1',
+      'https://test.com',
+      ['*'],
+      '1.0',
+    );
   });
 
   it('should call testEndpoint on the service', async () => {

--- a/src/webhooks/controllers/webhook.controller.ts
+++ b/src/webhooks/controllers/webhook.controller.ts
@@ -2,16 +2,23 @@ import {
   Controller,
   Post,
   Get,
+  Patch,
   Delete,
   Body,
   Param,
   UseGuards,
   Request,
 } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { WebhookService } from '../services/webhook.service';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { UpdateWebhookEndpointDto } from '../dto/update-webhook-endpoint.dto';
+import { WEBHOOK_SCHEMA_VERSION_REGISTRY } from '../../modules/webhooks/schemas';
 
-@Controller('webhooks')
+@ApiTags('Webhooks')
+// Served on both /v1 and /v2 so existing consumers keep working while schema
+// version management is documented against /v2.
+@Controller({ path: 'webhooks', version: ['1', '2'] })
 @UseGuards(JwtAuthGuard)
 export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
@@ -19,12 +26,14 @@ export class WebhookController {
   @Post()
   async create(
     @Request() req,
-    @Body() body: { url: string; events: string[] },
+    @Body()
+    body: { url: string; events: string[]; preferredSchemaVersion?: string },
   ) {
     return this.webhookService.createEndpoint(
       req.user.id,
       body.url,
       body.events,
+      body.preferredSchemaVersion,
     );
   }
 
@@ -32,6 +41,31 @@ export class WebhookController {
   async list(@Request() req) {
     const endpoints = await this.webhookService.listEndpoints(req.user.id);
     return endpoints.map(({ secret, ...rest }) => rest);
+  }
+
+  @Get('schema-versions')
+  @ApiOperation({
+    summary: 'List webhook payload schema versions and their sunset dates',
+  })
+  getSchemaVersions() {
+    return Object.values(WEBHOOK_SCHEMA_VERSION_REGISTRY);
+  }
+
+  @Patch(':id')
+  @ApiOperation({
+    summary: 'Update an endpoint, including its preferred payload schema version',
+  })
+  async update(
+    @Request() req,
+    @Param('id') id: string,
+    @Body() body: UpdateWebhookEndpointDto,
+  ) {
+    const { secret, ...rest } = await this.webhookService.updateEndpoint(
+      req.user.id,
+      id,
+      body,
+    );
+    return rest;
   }
 
   @Delete(':id')

--- a/src/webhooks/dto/update-webhook-endpoint.dto.ts
+++ b/src/webhooks/dto/update-webhook-endpoint.dto.ts
@@ -1,0 +1,43 @@
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  DEFAULT_WEBHOOK_SCHEMA_VERSION,
+  WEBHOOK_SCHEMA_VERSIONS,
+  WebhookSchemaVersion,
+} from '../../modules/webhooks/schemas';
+
+export class UpdateWebhookEndpointDto {
+  @ApiPropertyOptional({ example: 'https://example.com/hooks/nexafx' })
+  @IsOptional()
+  @IsString()
+  url?: string;
+
+  @ApiPropertyOptional({ example: ['transaction.completed'] })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  events?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Payload schema version to pin this endpoint to. 1.0 is deprecated — see docs/webhook-schema-versions.md.',
+    enum: WEBHOOK_SCHEMA_VERSIONS,
+    default: DEFAULT_WEBHOOK_SCHEMA_VERSION,
+  })
+  @IsOptional()
+  @IsIn([...WEBHOOK_SCHEMA_VERSIONS])
+  preferredSchemaVersion?: WebhookSchemaVersion;
+}

--- a/src/webhooks/entities/webhook-endpoint.entity.ts
+++ b/src/webhooks/entities/webhook-endpoint.entity.ts
@@ -5,6 +5,10 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import {
+  DEFAULT_WEBHOOK_SCHEMA_VERSION,
+  WebhookSchemaVersion,
+} from '../../modules/webhooks/schemas';
 
 @Entity('webhook_endpoints')
 export class WebhookEndpoint {
@@ -25,6 +29,18 @@ export class WebhookEndpoint {
 
   @Column({ default: true })
   isActive: boolean;
+
+  /**
+   * Payload schema version this endpoint is pinned to. New endpoints default to
+   * the latest version; endpoints that predate versioning were backfilled to
+   * '1.0' so their payload shape did not change underneath them.
+   */
+  @Column({
+    type: 'varchar',
+    length: 10,
+    default: DEFAULT_WEBHOOK_SCHEMA_VERSION,
+  })
+  preferredSchemaVersion: WebhookSchemaVersion;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/webhooks/services/webhook.service.spec.ts
+++ b/src/webhooks/services/webhook.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { WebhookEndpoint } from '../entities/webhook-endpoint.entity';
 import { WebhookDelivery } from '../entities/webhook-delivery.entity';
 import { BadRequestException } from '@nestjs/common';
+import { AuditLogsService } from '../../audit-logs/audit-logs.service';
 import axios from 'axios';
 
 jest.mock('axios');
@@ -13,8 +14,11 @@ describe('WebhookService', () => {
   let service: WebhookService;
   let endpointRepo: any;
   let deliveryRepo: any;
+  let auditLogsService: any;
 
   beforeEach(async () => {
+    auditLogsService = { log: jest.fn().mockResolvedValue(undefined) };
+
     endpointRepo = {
       create: jest.fn().mockImplementation((dto) => dto),
       save: jest
@@ -55,6 +59,10 @@ describe('WebhookService', () => {
             add: jest.fn(),
           },
         },
+        {
+          provide: AuditLogsService,
+          useValue: auditLogsService,
+        },
       ],
     }).compile();
 
@@ -81,10 +89,105 @@ describe('WebhookService', () => {
       expect(endpoint.url).toBe('https://test.com');
       expect(endpoint.secret).toBeDefined();
     });
+
+    it('should leave preferredSchemaVersion to the column default', async () => {
+      await service.createEndpoint('user1', 'https://test.com', ['*']);
+
+      expect(
+        endpointRepo.create.mock.calls[0][0],
+      ).not.toHaveProperty('preferredSchemaVersion');
+    });
+
+    it('should accept an explicit supported schema version', async () => {
+      const endpoint = await service.createEndpoint(
+        'user1',
+        'https://test.com',
+        ['*'],
+        '1.0',
+      );
+      expect(endpoint.preferredSchemaVersion).toBe('1.0');
+    });
+
+    it('should reject an unsupported schema version', async () => {
+      await expect(
+        service.createEndpoint('user1', 'https://test.com', ['*'], '3.0'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('updateEndpoint', () => {
+    it('should throw BadRequestException if endpoint not found', async () => {
+      endpointRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.updateEndpoint('user1', 'endpoint1', {
+          preferredSchemaVersion: '1.0',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should pin the endpoint to the requested schema version', async () => {
+      endpointRepo.findOne.mockResolvedValue({
+        id: '1',
+        userId: 'user1',
+        url: 'https://test.com',
+        events: ['*'],
+        preferredSchemaVersion: '2.0',
+      });
+
+      const updated = await service.updateEndpoint('user1', '1', {
+        preferredSchemaVersion: '1.0',
+      });
+
+      expect(updated.preferredSchemaVersion).toBe('1.0');
+      expect(endpointRepo.save).toHaveBeenCalled();
+    });
+
+    it('should reject an unsupported schema version', async () => {
+      endpointRepo.findOne.mockResolvedValue({
+        id: '1',
+        userId: 'user1',
+        url: 'https://test.com',
+        events: ['*'],
+        preferredSchemaVersion: '2.0',
+      });
+
+      await expect(
+        service.updateEndpoint('user1', '1', {
+          preferredSchemaVersion: '9.9' as any,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should re-validate a replacement url', async () => {
+      endpointRepo.findOne.mockResolvedValue({
+        id: '1',
+        userId: 'user1',
+        url: 'https://test.com',
+        events: ['*'],
+        preferredSchemaVersion: '2.0',
+      });
+
+      await expect(
+        service.updateEndpoint('user1', '1', { url: 'http://insecure.com' }),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 
   describe('dispatch', () => {
-    it('should shape payload correctly and execute delivery without awaiting', async () => {
+    const rawTransaction = {
+      id: 'tx-1',
+      userId: 'user1',
+      type: 'SWAP',
+      status: 'SUCCESS',
+      amount: '150.00000000',
+      currency: 'USD',
+      feeAmount: '1.50000000',
+      feeCurrency: 'USD',
+      txHash: 'hash-abc',
+      userNote: 'private note',
+    };
+
+    it('should deliver the v1 payload shape to a 1.0 endpoint', async () => {
       endpointRepo.find.mockResolvedValue([
         {
           id: '1',
@@ -92,20 +195,186 @@ describe('WebhookService', () => {
           events: ['*'],
           secret: 'test-secret',
           isActive: true,
+          preferredSchemaVersion: '1.0',
         },
       ]);
+
+      await service.dispatch('transaction.completed', rawTransaction, 'user1');
+
+      const { payload } = deliveryRepo.create.mock.calls[0][0];
+
+      expect(payload.schemaVersion).toBe('1.0');
+      expect(payload.event).toBe('transaction.completed');
+      expect(payload.id).toBeDefined();
+      expect(payload.timestamp).toBeDefined();
+      expect(payload.data).toEqual(rawTransaction);
+    });
+
+    it('should deliver the v2 payload shape to a 2.0 endpoint', async () => {
+      endpointRepo.find.mockResolvedValue([
+        {
+          id: '1',
+          url: 'https://test.com',
+          events: ['*'],
+          secret: 'test-secret',
+          isActive: true,
+          preferredSchemaVersion: '2.0',
+        },
+      ]);
+
+      await service.dispatch('transaction.completed', rawTransaction, 'user1');
+
+      const { payload } = deliveryRepo.create.mock.calls[0][0];
+
+      expect(payload.schemaVersion).toBe('2.0');
+      expect(payload.data.transactionId).toBe('tx-1');
+      expect(payload.data.amount).toBe(150);
+      expect(payload.data.status).toBe('success');
+      expect(payload.data.fee).toEqual({ amount: 1.5, currency: 'USD' });
+      expect(payload.data.stellarTxHash).toBe('hash-abc');
+      expect(payload.data).not.toHaveProperty('userNote');
+    });
+
+    it('should give each endpoint its own shape but one shared event id', async () => {
+      endpointRepo.find.mockResolvedValue([
+        {
+          id: '1',
+          url: 'https://one.com',
+          events: ['*'],
+          secret: 's1',
+          isActive: true,
+          preferredSchemaVersion: '1.0',
+        },
+        {
+          id: '2',
+          url: 'https://two.com',
+          events: ['*'],
+          secret: 's2',
+          isActive: true,
+          preferredSchemaVersion: '2.0',
+        },
+      ]);
+
+      await service.dispatch('transaction.completed', rawTransaction, 'user1');
+
+      const first = deliveryRepo.create.mock.calls[0][0].payload;
+      const second = deliveryRepo.create.mock.calls[1][0].payload;
+
+      expect(first.schemaVersion).toBe('1.0');
+      expect(second.schemaVersion).toBe('2.0');
+      expect(first.id).toBe(second.id);
+      expect(first.timestamp).toBe(second.timestamp);
+    });
+  });
+
+  describe('executeDelivery schema headers', () => {
+    const delivery = (schemaVersion: string) => ({
+      id: 'delivery-1',
+      endpointId: '1',
+      eventType: 'transaction.completed',
+      payload: { schemaVersion, event: 'transaction.completed', data: {} },
+      attemptCount: 0,
+    });
+
+    const endpoint = (preferredSchemaVersion: string) => ({
+      id: '1',
+      userId: 'user1',
+      url: 'https://test.com',
+      secret: 'test-secret',
+      isActive: true,
+      preferredSchemaVersion,
+    });
+
+    beforeEach(() => {
       mockedAxios.post.mockResolvedValue({ status: 200, data: 'OK' });
+    });
 
-      await service.dispatch('transaction.completed', { foo: 'bar' }, 'user1');
+    it('should send deprecation headers to a 1.0 endpoint', async () => {
+      await service.executeDelivery(
+        delivery('1.0') as any,
+        endpoint('1.0') as any,
+      );
 
-      expect(deliveryRepo.create).toHaveBeenCalled();
-      const createdDelivery = deliveryRepo.create.mock.calls[0][0];
+      const { headers } = mockedAxios.post.mock.calls[0][2] as any;
 
-      expect(createdDelivery.eventType).toBe('transaction.completed');
-      expect(createdDelivery.payload.id).toBeDefined();
-      expect(createdDelivery.payload.event).toBe('transaction.completed');
-      expect(createdDelivery.payload.data).toEqual({ foo: 'bar' });
-      expect(createdDelivery.payload.timestamp).toBeDefined();
+      expect(headers['X-NexaFX-Schema-Version']).toBe('1.0');
+      expect(headers['X-NexaFX-Schema-Deprecated']).toBe('true');
+      expect(headers['Deprecation']).toBe('true');
+      expect(headers['Sunset']).toMatch(/GMT$/);
+    });
+
+    it('should not send deprecation headers to a 2.0 endpoint', async () => {
+      await service.executeDelivery(
+        delivery('2.0') as any,
+        endpoint('2.0') as any,
+      );
+
+      const { headers } = mockedAxios.post.mock.calls[0][2] as any;
+
+      expect(headers['X-NexaFX-Schema-Version']).toBe('2.0');
+      expect(headers['X-NexaFX-Schema-Deprecated']).toBeUndefined();
+      expect(headers['Deprecation']).toBeUndefined();
+      expect(headers['Sunset']).toBeUndefined();
+    });
+
+    it('should log webhook.deprecated_schema_used for 1.0 deliveries', async () => {
+      await service.executeDelivery(
+        delivery('1.0') as any,
+        endpoint('1.0') as any,
+      );
+
+      expect(auditLogsService.log).toHaveBeenCalledWith(
+        'user1',
+        'webhook.deprecated_schema_used',
+        'WEBHOOK_ENDPOINT',
+        '1',
+        'SUCCESS',
+        expect.objectContaining({
+          schemaVersion: '1.0',
+          eventType: 'transaction.completed',
+          deliveryId: 'delivery-1',
+        }),
+      );
+    });
+
+    it('should not log a deprecation audit event for 2.0 deliveries', async () => {
+      await service.executeDelivery(
+        delivery('2.0') as any,
+        endpoint('2.0') as any,
+      );
+
+      expect(auditLogsService.log).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the endpoint preference for pre-versioning deliveries', async () => {
+      const legacyDelivery = {
+        id: 'delivery-legacy',
+        endpointId: '1',
+        eventType: 'transaction.completed',
+        payload: { event: 'transaction.completed', data: {} },
+        attemptCount: 0,
+      };
+
+      await service.executeDelivery(
+        legacyDelivery as any,
+        endpoint('1.0') as any,
+      );
+
+      const { headers } = mockedAxios.post.mock.calls[0][2] as any;
+      expect(headers['X-NexaFX-Schema-Version']).toBe('1.0');
+      expect(headers['X-NexaFX-Schema-Deprecated']).toBe('true');
+    });
+
+    it('should still deliver when the audit write fails', async () => {
+      auditLogsService.log.mockRejectedValueOnce(new Error('audit down'));
+
+      await service.executeDelivery(
+        delivery('1.0') as any,
+        endpoint('1.0') as any,
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalled();
+      expect(deliveryRepo.save).toHaveBeenCalled();
     });
   });
 

--- a/src/webhooks/services/webhook.service.ts
+++ b/src/webhooks/services/webhook.service.ts
@@ -7,6 +7,16 @@ import { WebhookEndpoint } from '../entities/webhook-endpoint.entity';
 import { WebhookDelivery } from '../entities/webhook-delivery.entity';
 import { WEBHOOK_QUEUE } from '../../modules/queues/queue.constants';
 import type { WebhookDeliveryJob } from '../../modules/webhooks/webhook.processor';
+import {
+  buildSchemaHeaders,
+  getSchemaVersionInfo,
+  isDeprecatedSchemaVersion,
+  WEBHOOK_SCHEMA_VERSIONS,
+  WebhookSchemaTransformer,
+  WebhookSchemaVersion,
+} from '../../modules/webhooks/schemas';
+import { AuditLogsService } from '../../audit-logs/audit-logs.service';
+import { UpdateWebhookEndpointDto } from '../dto/update-webhook-endpoint.dto';
 import * as crypto from 'crypto';
 import axios from 'axios';
 import { URL } from 'url';
@@ -28,6 +38,7 @@ export class WebhookService {
     private readonly deliveryRepo: Repository<WebhookDelivery>,
     @InjectQueue(WEBHOOK_QUEUE)
     private readonly webhookQueue: Queue<WebhookDeliveryJob>,
+    private readonly auditLogsService: AuditLogsService,
   ) {}
 
   private validateWebhookUrl(raw: string): void {
@@ -45,10 +56,22 @@ export class WebhookService {
     }
   }
 
+  private assertSupportedSchemaVersion(version: string): WebhookSchemaVersion {
+    if (!WebhookSchemaTransformer.isSupportedVersion(version)) {
+      throw new BadRequestException(
+        `Unsupported schema version '${version}'. Supported versions: ${WEBHOOK_SCHEMA_VERSIONS.join(
+          ', ',
+        )}`,
+      );
+    }
+    return version;
+  }
+
   async createEndpoint(
     userId: string,
     url: string,
     events: string[],
+    preferredSchemaVersion?: string,
   ): Promise<WebhookEndpoint> {
     this.validateWebhookUrl(url);
 
@@ -58,7 +81,41 @@ export class WebhookService {
       events,
       secret: crypto.randomBytes(32).toString('hex'),
       isActive: true,
+      // Left undefined so the column default (latest version) applies.
+      ...(preferredSchemaVersion !== undefined && {
+        preferredSchemaVersion:
+          this.assertSupportedSchemaVersion(preferredSchemaVersion),
+      }),
     });
+
+    return this.endpointRepo.save(endpoint);
+  }
+
+  async updateEndpoint(
+    userId: string,
+    id: string,
+    updates: UpdateWebhookEndpointDto,
+  ): Promise<WebhookEndpoint> {
+    const endpoint = await this.endpointRepo.findOne({ where: { id, userId } });
+    if (!endpoint) {
+      throw new BadRequestException('Endpoint not found');
+    }
+
+    if (updates.url !== undefined) {
+      this.validateWebhookUrl(updates.url);
+      endpoint.url = updates.url;
+    }
+    if (updates.events !== undefined) {
+      endpoint.events = updates.events;
+    }
+    if (updates.isActive !== undefined) {
+      endpoint.isActive = updates.isActive;
+    }
+    if (updates.preferredSchemaVersion !== undefined) {
+      endpoint.preferredSchemaVersion = this.assertSupportedSchemaVersion(
+        updates.preferredSchemaVersion,
+      );
+    }
 
     return this.endpointRepo.save(endpoint);
   }
@@ -72,14 +129,20 @@ export class WebhookService {
       (e) => e.events.includes(eventType) || e.events.includes('*'),
     );
 
-    const payload = {
-      id: crypto.randomUUID(),
-      event: eventType,
-      data,
-      timestamp: new Date().toISOString(),
-    };
+    // One event id and timestamp shared across the fan-out, so consumers can
+    // still correlate the same event across endpoints that are pinned to
+    // different schema versions.
+    const eventId = crypto.randomUUID();
+    const timestamp = new Date().toISOString();
 
     for (const endpoint of relevantEndpoints) {
+      const payload = WebhookSchemaTransformer.transform(
+        eventType,
+        data,
+        endpoint.preferredSchemaVersion,
+        { id: eventId, timestamp },
+      );
+
       const delivery = this.deliveryRepo.create({
         endpointId: endpoint.id,
         eventType,
@@ -123,6 +186,17 @@ export class WebhookService {
       .update(payloadString)
       .digest('hex');
 
+    // Prefer the version the payload was actually shaped for; fall back to the
+    // endpoint's preference for deliveries stored before versioning shipped.
+    const schemaVersion = WebhookSchemaTransformer.resolveVersion(
+      (delivery.payload as { schemaVersion?: string } | null)?.schemaVersion ??
+        endpoint.preferredSchemaVersion,
+    );
+
+    if (isDeprecatedSchemaVersion(schemaVersion)) {
+      this.recordDeprecatedSchemaUsage(endpoint, delivery, schemaVersion);
+    }
+
     delivery.attemptCount++;
 
     try {
@@ -134,6 +208,7 @@ export class WebhookService {
           'Content-Type': 'application/json',
           'X-NexaFX-Signature': `sha256=${signature}`,
           'User-Agent': 'NexaFX-Webhook/1.0',
+          ...buildSchemaHeaders(schemaVersion),
         },
         timeout: 10000,
         maxRedirects: 0, // prevent redirect-based SSRF
@@ -167,6 +242,47 @@ export class WebhookService {
     }
 
     await this.deliveryRepo.save(delivery);
+  }
+
+  /**
+   * Records that a delivery went out on a deprecated schema version.
+   *
+   * Fire-and-forget: audit bookkeeping must never add latency to, or fail, a
+   * webhook delivery. AuditLogsService.log already swallows its own errors.
+   */
+  private recordDeprecatedSchemaUsage(
+    endpoint: WebhookEndpoint,
+    delivery: WebhookDelivery,
+    schemaVersion: WebhookSchemaVersion,
+  ): void {
+    const { deprecatedOn, sunsetOn } = getSchemaVersionInfo(schemaVersion);
+
+    this.logger.warn(
+      `Endpoint ${endpoint.id} received event ${delivery.eventType} on deprecated schema ${schemaVersion} (sunset ${sunsetOn})`,
+    );
+
+    this.auditLogsService
+      .log(
+        endpoint.userId ?? null,
+        'webhook.deprecated_schema_used',
+        'WEBHOOK_ENDPOINT',
+        endpoint.id,
+        'SUCCESS',
+        {
+          schemaVersion,
+          eventType: delivery.eventType,
+          deliveryId: delivery.id,
+          deprecatedOn,
+          sunsetOn,
+        },
+      )
+      .catch((error: unknown) => {
+        this.logger.warn(
+          `Failed to record deprecated schema audit event: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
   }
 
   async processRetries(): Promise<void> {
@@ -238,12 +354,11 @@ export class WebhookService {
       throw new BadRequestException('Endpoint not found');
     }
 
-    const payload = {
-      id: crypto.randomUUID(),
-      event: 'ping',
-      data: { message: 'Test ping from NexaFX' },
-      timestamp: new Date().toISOString(),
-    };
+    const payload = WebhookSchemaTransformer.transform(
+      'ping',
+      { message: 'Test ping from NexaFX' },
+      endpoint.preferredSchemaVersion,
+    );
 
     const delivery = this.deliveryRepo.create({
       endpointId: endpoint.id,

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -6,11 +6,13 @@ import { WebhookService } from './services/webhook.service';
 import { WebhookController } from './controllers/webhook.controller';
 import { QueuesModule } from '../modules/queues/queues.module';
 import { WebhookProcessor } from '../modules/webhooks/webhook.processor';
+import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([WebhookEndpoint, WebhookDelivery]),
     QueuesModule,
+    AuditLogsModule,
   ],
   providers: [WebhookService, WebhookProcessor],
   controllers: [WebhookController],


### PR DESCRIPTION
closes #785 

---

# Webhook Schema Versioning

## Implementation Overview

| Component | Location |
|-----------|----------|
| Version registry, deprecation dates, header builder | `webhook-schema-version.ts` |
| Frozen v1.0 / curated v2.0 payload builders | `transaction-completed.v1.ts`, `transaction-completed.v2.ts` |
| `WebhookSchemaTransformer.transform(event, data, version)` | `webhook-schema.transformer.ts` |
| `preferredSchemaVersion` column | `webhook-endpoint.entity.ts` + migration file |
| `PATCH /v2/webhooks/:id`, `GET /v2/webhooks/schema-versions` | `webhook.controller.ts` |
| Per-endpoint payload shaping, deprecation headers, audit events | `webhook.service.ts` |
| Migration guide | `docs/webhook-schema-versions.md` |

---

## Key Behaviors

### 1. Backward Compatibility
Existing endpoints are automatically backfilled to schema version **1.0**, ensuring zero disruption to current integrations.

### 2. Per-Endpoint Payload Shaping
The `dispatch` process constructs a custom payload for each endpoint, while maintaining a single shared event `id` across all fan-out deliveries.

### 3. Deprecation Signaling
All v1 deliveries include the following RFC 8594-compliant headers:
- `X-NexaFX-Schema-Deprecated`
- `Deprecation`
- `Sunset` (with HTTP-date format)

### 4. Audit Logging
Each v1 delivery triggers a `webhook.deprecated_schema_used` audit log entry, providing full visibility into legacy schema usage.

---

## Key Improvements Made

- **Table formatting** – Clean, readable markdown table with aligned columns
- **Clear section hierarchy** – Separate overview and behavior sections
- **Concise bullet points** – Each behavior explained in 1–2 sentences
- **Consistent terminology** – "v1" and "v2" throughout instead of mixing "1.0" and "2.0"
- **Professional tone** – Removed informal language, focused on clarity
- **Active voice** – More direct and actionable phrasing
- **Contextual headers** – RFC 8594 referenced clearly without cluttering the flow

---