### PR TITLE
Batch

### DIFF
--- a/src/batches/batches-v2.controller.spec.ts
+++ b/src/batches/batches-v2.controller.spec.ts
@@ -1,0 +1,154 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CallHandler, ExecutionContext, HttpStatus } from '@nestjs/common';
+import { of } from 'rxjs';
+import Decimal from 'decimal.js';
+import { BatchesV2Controller } from './batches-v2.controller';
+import { IdempotencyInterceptor } from '../common/interceptors/idempotency.interceptor';
+import { IdempotencyService } from '../common/services/idempotency.service';
+import { TransactionsService } from '../transactions/services/transaction.service';
+
+describe('BatchesV2Controller', () => {
+  let controller: BatchesV2Controller;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BatchesV2Controller],
+      providers: [
+        {
+          provide: TransactionsService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<BatchesV2Controller>(BatchesV2Controller);
+  });
+
+  it('returns a successful transaction response for the authenticated user', async () => {
+    const batchId = 'batch-123';
+    const userId = 'user-456';
+
+    const response = await controller.executeBatch(
+      batchId,
+      { user: { userId } },
+      { reference: 'user-note-123' },
+    );
+
+    expect(response).toMatchObject({
+      id: batchId,
+      userId,
+      currency: 'XLM',
+      status: 'SUCCESS',
+    });
+    expect(new Decimal(response.amount).isZero()).toBe(true);
+    expect(response.createdAt).toBeInstanceOf(Date);
+    expect(response.updatedAt).toBeInstanceOf(Date);
+  });
+
+  describe('Idempotency-Key enforcement for the v2 endpoint', () => {
+    const mockService = {
+      validateIdempotencyKey: jest.fn(),
+      checkIdempotency: jest.fn(),
+      storeIdempotency: jest.fn(),
+    };
+
+    const createContext = (
+      headers: Record<string, string>,
+      routePath = '/v2/batches/:id/execute',
+    ) => {
+      const response = {
+        setHeader: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+      };
+      const request = {
+        method: 'POST',
+        url: '/v2/batches/batch-123/execute',
+        route: { path: routePath },
+        headers,
+        body: { reference: 'test' },
+        user: { id: 'user-456' },
+      };
+
+      return {
+        context: {
+          switchToHttp: () => ({
+            getRequest: () => request,
+            getResponse: () => response,
+          }),
+        } as unknown as ExecutionContext,
+        response,
+      };
+    };
+
+    const createInterceptor = async () => {
+      const module = await Test.createTestingModule({
+        providers: [
+          IdempotencyInterceptor,
+          { provide: IdempotencyService, useValue: mockService },
+        ],
+      }).compile();
+
+      return module.get<IdempotencyInterceptor>(IdempotencyInterceptor);
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns 422 when the required key is missing', (done) => {
+      const { context } = createContext({});
+      createInterceptor().then((interceptor) => {
+        interceptor.intercept(context, {} as CallHandler).subscribe({
+          error: (error) => {
+            expect(error.status).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+            expect(error.message).toContain('Idempotency-Key');
+            done();
+          },
+        });
+      });
+    });
+
+    it('passes a valid key through and echoes it in the response header', (done) => {
+      const { context, response } = createContext({
+        'idempotency-key': 'batch_exec_123',
+      });
+      mockService.validateIdempotencyKey.mockReturnValue({ valid: true });
+      mockService.checkIdempotency.mockResolvedValue(null);
+
+      createInterceptor().then((interceptor) => {
+        interceptor
+          .intercept(context, {
+            handle: () => of({ id: 'batch-123' }),
+          } as CallHandler)
+          .subscribe({
+            next: (body) => {
+              expect(body).toEqual({ id: 'batch-123' });
+              expect(response.setHeader).toHaveBeenCalledWith(
+                'Idempotency-Key',
+                'batch_exec_123',
+              );
+              done();
+            },
+          });
+      });
+    });
+
+    it('returns 400 for an invalid key format', (done) => {
+      const { context } = createContext({ 'idempotency-key': 'invalid key' });
+      mockService.validateIdempotencyKey.mockReturnValue({
+        valid: false,
+        error: 'invalid key format',
+      });
+
+      createInterceptor().then((interceptor) => {
+        interceptor.intercept(context, {} as CallHandler).subscribe({
+          error: (error) => {
+            expect(error.status).toBe(HttpStatus.BAD_REQUEST);
+            expect(error.message).toBe('invalid key format');
+            done();
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/batches/batches-v2.module.spec.ts
+++ b/src/batches/batches-v2.module.spec.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('BatchesV2Module', () => {
+  it('registers the v2 batch controller', () => {
+    const moduleSource = readFileSync(
+      join(__dirname, 'batches-v2.module.ts'),
+      'utf8',
+    );
+
+    expect(moduleSource).toContain("import { BatchesV2Controller } from './batches-v2.controller';");
+    expect(moduleSource).toContain('controllers: [BatchesV2Controller]');
+  });
+});

--- a/src/bridge-prep/bridge-prep.controller.spec.ts
+++ b/src/bridge-prep/bridge-prep.controller.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BridgePrepController } from './bridge-prep.controller';
+import { BridgePrepService } from './bridge-prep.service';
+
+describe('BridgePrepController', () => {
+  let controller: BridgePrepController;
+  const bridgePrepService = {
+    getAllNetworks: jest.fn(),
+    getBridgeStatus: jest.fn(),
+    saveWallet: jest.fn(),
+    getUserWallets: jest.fn(),
+    removeWallet: jest.fn(),
+    initiateVerification: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BridgePrepController],
+      providers: [{ provide: BridgePrepService, useValue: bridgePrepService }],
+    }).compile();
+
+    controller = module.get<BridgePrepController>(BridgePrepController);
+    jest.clearAllMocks();
+  });
+
+  it('delegates network and bridge-status reads', async () => {
+    bridgePrepService.getAllNetworks.mockResolvedValue(['network']);
+    bridgePrepService.getBridgeStatus.mockResolvedValue({ live: [], comingSoon: [] });
+
+    await expect(controller.getNetworks()).resolves.toEqual(['network']);
+    await expect(controller.getStatus()).resolves.toEqual({ live: [], comingSoon: [] });
+  });
+
+  it('delegates wallet creation with the authenticated user and body fields', async () => {
+    bridgePrepService.saveWallet.mockResolvedValue({ id: 'wallet-1' });
+    const body = { networkId: 'network-1', address: 'address', label: 'Main' };
+
+    await expect(controller.saveWallet({ user: { id: 'user-1' } }, body)).resolves.toEqual({
+      id: 'wallet-1',
+    });
+    expect(bridgePrepService.saveWallet).toHaveBeenCalledWith(
+      'user-1',
+      'network-1',
+      'address',
+      'Main',
+    );
+  });
+
+  it.each([
+    ['getWallets', () => controller.getWallets({ user: { id: 'user-1' } })],
+    ['removeWallet', () => controller.removeWallet('wallet-1', { user: { id: 'user-1' } })],
+    ['verifyWallet', () => controller.verifyWallet('wallet-1', { user: { id: 'user-1' } })],
+  ])('delegates %s with the authenticated user scope', async (_name, action) => {
+    await action();
+    expect(bridgePrepService.getUserWallets.mock.calls.length +
+      bridgePrepService.removeWallet.mock.calls.length +
+      bridgePrepService.initiateVerification.mock.calls.length).toBe(1);
+  });
+});

--- a/src/bridge-prep/bridge-prep.module.spec.ts
+++ b/src/bridge-prep/bridge-prep.module.spec.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('BridgePrepModule', () => {
+  it('registers the controller and bridge-prep providers', () => {
+    const moduleSource = readFileSync(
+      join(__dirname, 'bridge-prep.module.ts'),
+      'utf8',
+    );
+
+    expect(moduleSource).toContain('controllers: [BridgePrepController]');
+    expect(moduleSource).toContain(
+      'providers: [BridgePrepService, AddressValidationService]',
+    );
+    expect(moduleSource).toContain(
+      'TypeOrmModule.forFeature([BlockchainNetwork, ExternalWalletAddress, BridgeTransaction])',
+    );
+  });
+});

--- a/src/bridge-prep/bridge-prep.service.spec.ts
+++ b/src/bridge-prep/bridge-prep.service.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BridgePrepService } from './bridge-prep.service';
+import { AddressValidationService } from './services/address-validation.service';
+import { BlockchainNetwork, AddressFormatType } from './entities/blockchain-network.entity';
+import { ExternalWalletAddress } from './entities/external-wallet-address.entity';
+
+describe('BridgePrepService', () => {
+  let service: BridgePrepService;
+  const networkRepo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+  };
+  const walletRepo = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  };
+  const validationService = { validate: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BridgePrepService,
+        { provide: getRepositoryToken(BlockchainNetwork), useValue: networkRepo },
+        { provide: getRepositoryToken(ExternalWalletAddress), useValue: walletRepo },
+        { provide: AddressValidationService, useValue: validationService },
+      ],
+    }).compile();
+
+    service = module.get<BridgePrepService>(BridgePrepService);
+    jest.clearAllMocks();
+  });
+
+  it('returns only active networks', async () => {
+    const networks = [{ id: 'stellar', isActive: true } as BlockchainNetwork];
+    networkRepo.find.mockResolvedValue(networks);
+
+    await expect(service.getAllNetworks()).resolves.toBe(networks);
+    expect(networkRepo.find).toHaveBeenCalledWith({ where: { isActive: true } });
+  });
+
+  it('separates active networks into live and coming-soon lists', async () => {
+    networkRepo.find.mockResolvedValue([
+      { name: 'Stellar', isSupported: true },
+      { name: 'Ethereum', isSupported: false },
+    ]);
+
+    await expect(service.getBridgeStatus()).resolves.toEqual({
+      live: ['Stellar'],
+      comingSoon: ['Ethereum'],
+    });
+  });
+
+  it('validates and saves a wallet for a registered network', async () => {
+    const network = { id: 'network-1', addressFormat: AddressFormatType.EVM };
+    const wallet = { id: 'wallet-1', userId: 'user-1' };
+    networkRepo.findOne.mockResolvedValue(network);
+    validationService.validate.mockReturnValue({ valid: true, format: 'EVM' });
+    walletRepo.create.mockReturnValue(wallet);
+    walletRepo.save.mockResolvedValue(wallet);
+
+    await expect(
+      service.saveWallet('user-1', 'network-1', `0x${'a'.repeat(40)}`, 'Main'),
+    ).resolves.toBe(wallet);
+    expect(walletRepo.create).toHaveBeenCalledWith({
+      userId: 'user-1',
+      networkId: 'network-1',
+      address: `0x${'a'.repeat(40)}`,
+      label: 'Main',
+      isVerified: false,
+    });
+  });
+
+  it('rejects a malformed wallet address before saving', async () => {
+    networkRepo.findOne.mockResolvedValue({ addressFormat: AddressFormatType.STELLAR });
+    validationService.validate.mockReturnValue({
+      valid: false,
+      format: 'STELLAR',
+      error: 'Invalid Stellar public address pattern',
+    });
+
+    await expect(service.saveWallet('user-1', 'network-1', 'bad')).rejects.toThrow(
+      new BadRequestException('Invalid Stellar public address pattern'),
+    );
+    expect(walletRepo.create).not.toHaveBeenCalled();
+    expect(walletRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unregistered network before address validation', async () => {
+    networkRepo.findOne.mockResolvedValue(null);
+
+    await expect(service.saveWallet('user-1', 'missing', 'address')).rejects.toThrow(
+      new NotFoundException('Target blockchain network profile missing'),
+    );
+    expect(validationService.validate).not.toHaveBeenCalled();
+  });
+
+  it('currently passes duplicate wallet registrations to the repository', async () => {
+    const network = { id: 'network-1', addressFormat: AddressFormatType.EVM };
+    networkRepo.findOne.mockResolvedValue(network);
+    validationService.validate.mockReturnValue({ valid: true, format: 'EVM' });
+    walletRepo.create.mockImplementation((value) => value);
+    walletRepo.save.mockImplementation(async (value) => value);
+
+    await service.saveWallet('user-1', 'network-1', `0x${'b'.repeat(40)}`);
+    await service.saveWallet('user-1', 'network-1', `0x${'b'.repeat(40)}`);
+
+    expect(walletRepo.save).toHaveBeenCalledTimes(2);
+  });
+
+  it('limits wallet reads and removal to the authenticated user', async () => {
+    const wallets = [{ id: 'wallet-1' }];
+    walletRepo.find.mockResolvedValue(wallets);
+    walletRepo.findOne.mockResolvedValue(wallets[0]);
+
+    await expect(service.getUserWallets('user-1')).resolves.toBe(wallets);
+    await expect(service.removeWallet('wallet-1', 'user-1')).resolves.toBeUndefined();
+    expect(walletRepo.find).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      relations: ['network'],
+    });
+    expect(walletRepo.findOne).toHaveBeenCalledWith({
+      where: { id: 'wallet-1', userId: 'user-1' },
+    });
+    expect(walletRepo.remove).toHaveBeenCalledWith(wallets[0]);
+  });
+
+  it('rejects removing or verifying a wallet outside the user scope', async () => {
+    walletRepo.findOne.mockResolvedValue(null);
+
+    await expect(service.removeWallet('wallet-1', 'user-1')).rejects.toThrow(NotFoundException);
+    await expect(service.initiateVerification('wallet-1', 'user-1')).rejects.toThrow(
+      new NotFoundException('Target wallet profile unassigned'),
+    );
+  });
+
+  it('generates a verification challenge for an owned wallet', async () => {
+    walletRepo.findOne.mockResolvedValue({ id: 'wallet-1' });
+
+    await expect(service.initiateVerification('wallet-1', 'user-1')).resolves.toEqual({
+      id: 'wallet-1',
+      verificationStatus: 'CHALLENGE_GENERATED',
+      challenge: 'Sign this state update footprint',
+    });
+  });
+});

--- a/src/bridge-prep/entities/blockchain-network.entity.spec.ts
+++ b/src/bridge-prep/entities/blockchain-network.entity.spec.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata';
+import { getMetadataArgsStorage } from 'typeorm';
+import { BlockchainNetwork } from './blockchain-network.entity';
+
+describe('BlockchainNetwork entity', () => {
+  it('maps the network registry to the expected table and fields', () => {
+    const table = getMetadataArgsStorage().tables.find((entry) => entry.target === BlockchainNetwork);
+    const columns = getMetadataArgsStorage().columns
+      .filter((entry) => entry.target === BlockchainNetwork)
+      .map((entry) => entry.propertyName);
+
+    expect(table?.name).toBe('blockchain_networks');
+    expect(columns).toEqual(expect.arrayContaining([
+      'name', 'chainId', 'symbol', 'isSupported', 'explorerUrl',
+      'avgConfirmationSeconds', 'addressFormat', 'isActive',
+    ]));
+  });
+});

--- a/src/bridge-prep/entities/bridge-transaction.entity.spec.ts
+++ b/src/bridge-prep/entities/bridge-transaction.entity.spec.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata';
+import { getMetadataArgsStorage } from 'typeorm';
+import { BridgeTransaction } from './bridge-transaction.entity';
+
+describe('BridgeTransaction entity', () => {
+  it('maps source, destination, asset, amount, and status fields', () => {
+    const table = getMetadataArgsStorage().tables.find((entry) => entry.target === BridgeTransaction);
+    const columns = getMetadataArgsStorage().columns
+      .filter((entry) => entry.target === BridgeTransaction)
+      .map((entry) => entry.propertyName);
+
+    expect(table?.name).toBe('bridge_transactions');
+    expect(columns).toEqual(expect.arrayContaining([
+      'userId', 'sourceNetworkId', 'destinationNetworkId', 'sourceAddress',
+      'destinationAddress', 'assetCode', 'amount', 'status', 'feeAmount',
+    ]));
+  });
+});

--- a/src/bridge-prep/entities/external-wallet-address.entity.spec.ts
+++ b/src/bridge-prep/entities/external-wallet-address.entity.spec.ts
@@ -1,0 +1,17 @@
+import 'reflect-metadata';
+import { getMetadataArgsStorage } from 'typeorm';
+import { ExternalWalletAddress } from './external-wallet-address.entity';
+
+describe('ExternalWalletAddress entity', () => {
+  it('maps wallet ownership and address fields', () => {
+    const table = getMetadataArgsStorage().tables.find((entry) => entry.target === ExternalWalletAddress);
+    const columns = getMetadataArgsStorage().columns
+      .filter((entry) => entry.target === ExternalWalletAddress)
+      .map((entry) => entry.propertyName);
+
+    expect(table?.name).toBe('external_wallet_addresses');
+    expect(columns).toEqual(expect.arrayContaining([
+      'userId', 'networkId', 'address', 'label', 'isVerified', 'verificationMethod',
+    ]));
+  });
+});

--- a/src/bridge-prep/services/address-validation.service.spec.ts
+++ b/src/bridge-prep/services/address-validation.service.spec.ts
@@ -1,0 +1,41 @@
+import { AddressFormatType } from '../entities/blockchain-network.entity';
+import { AddressValidationService } from './address-validation.service';
+
+describe('AddressValidationService', () => {
+  let service: AddressValidationService;
+
+  beforeEach(() => {
+    service = new AddressValidationService();
+  });
+
+  it.each([
+    [AddressFormatType.STELLAR, `G${'A'.repeat(55)}`],
+    [AddressFormatType.EVM, `0x${'a'.repeat(40)}`],
+    [AddressFormatType.SOLANA, '123456789ABCDEFGHJKLMNPQRSTUVWXYZ'],
+  ])('accepts a valid %s address', (format, address) => {
+    expect(service.validate(address, format)).toEqual({
+      valid: true,
+      format,
+    });
+  });
+
+  it.each([
+    [AddressFormatType.STELLAR, `G${'Z'.repeat(55)}`, 'Invalid Stellar'],
+    [AddressFormatType.EVM, '0xnot-a-hex-address', 'Invalid hex'],
+    [AddressFormatType.SOLANA, '0'.repeat(32), 'Invalid Base58'],
+  ])('rejects a malformed %s address', (format, address, error) => {
+    const result = service.validate(address, format);
+
+    expect(result.valid).toBe(false);
+    expect(result.format).toBe(format);
+    expect(result.error).toContain(error);
+  });
+
+  it('rejects an unsupported address format', () => {
+    expect(service.validate('address', AddressFormatType.BASE58)).toEqual({
+      valid: false,
+      format: 'UNKNOWN',
+      error: 'Unsupported serialization layout type',
+    });
+  });
+});


### PR DESCRIPTION

Add unit test coverage for the bridge-prep module — 7 files, zero specs today
Summary
src/bridge-prep/ implements preparatory infrastructure for a future cross-chain bridge — blockchain network registry and external wallet address validation. It has 7 implementation files and, confirmed by find src/bridge-prep -name '*.spec.ts', zero test files. This issue adds a real unit test suite for the module's actual business logic — not placeholder smoke tests.

Added seven bridge-prep specs covering:

Address validation for Stellar, EVM, Solana, malformed addresses, and unsupported formats
Network filtering and bridge status grouping
Wallet validation, saving, ownership checks, verification, and error paths
Duplicate wallet behavior characterization
Controller delegation
Entity metadata
closes #901
closes #902