### PR TITLE
test: unit coverage for lending, kyc-ocr, and ip-blocklist modules

### DIFF
--- a/src/modules/ip-blocklist/ip-blocklist.guard.spec.ts
+++ b/src/modules/ip-blocklist/ip-blocklist.guard.spec.ts
@@ -1,0 +1,70 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { IpBlocklistGuard } from './ip-blocklist.guard';
+import { IpBlocklistService } from './ip-blocklist.service';
+
+function mockContext(req: Partial<{ headers: Record<string, string>; ip?: string; socket?: { remoteAddress?: string } }>): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('IpBlocklistGuard', () => {
+  let guard: IpBlocklistGuard;
+  let service: { isBlocked: jest.Mock };
+
+  beforeEach(() => {
+    service = { isBlocked: jest.fn() };
+    guard = new IpBlocklistGuard(service as unknown as IpBlocklistService);
+  });
+
+  it('allows a request from a clean IP', async () => {
+    service.isBlocked.mockResolvedValue(false);
+    const ctx = mockContext({ headers: {}, ip: '203.0.113.10' });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(service.isBlocked).toHaveBeenCalledWith('203.0.113.10');
+  });
+
+  it('blocks a request from a blocklisted IP', async () => {
+    service.isBlocked.mockResolvedValue(true);
+    const ctx = mockContext({ headers: {}, ip: '198.51.100.7' });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(/IP address has been blocked/);
+  });
+
+  it('uses first X-Forwarded-For hop for proxied requests', async () => {
+    service.isBlocked.mockResolvedValue(false);
+    const ctx = mockContext({
+      headers: { 'x-forwarded-for': '203.0.113.50, 10.0.0.1' },
+      ip: '10.0.0.1',
+    });
+    await guard.canActivate(ctx);
+    expect(service.isBlocked).toHaveBeenCalledWith('203.0.113.50');
+  });
+
+  it('falls back to socket.remoteAddress when ip and XFF are absent', async () => {
+    service.isBlocked.mockResolvedValue(false);
+    const ctx = mockContext({
+      headers: {},
+      socket: { remoteAddress: '192.0.2.1' },
+    });
+    await guard.canActivate(ctx);
+    expect(service.isBlocked).toHaveBeenCalledWith('192.0.2.1');
+  });
+
+  it('allows request when no client IP can be resolved', async () => {
+    const ctx = mockContext({ headers: {} });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(service.isBlocked).not.toHaveBeenCalled();
+  });
+
+  it('reflects blocklist mutations without restart (add then block)', async () => {
+    service.isBlocked.mockResolvedValueOnce(false);
+    const cleanCtx = mockContext({ headers: {}, ip: '198.51.100.9' });
+    await expect(guard.canActivate(cleanCtx)).resolves.toBe(true);
+
+    service.isBlocked.mockResolvedValueOnce(true);
+    await expect(guard.canActivate(cleanCtx)).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/src/modules/ip-blocklist/ip-blocklist.service.spec.ts
+++ b/src/modules/ip-blocklist/ip-blocklist.service.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IpBlocklistService } from './ip-blocklist.service';
+import { RedisService } from '../redis/redis.service';
+
+describe('IpBlocklistService', () => {
+  let service: IpBlocklistService;
+  let redis: {
+    key: jest.Mock;
+    exists: jest.Mock;
+    setString: jest.Mock;
+    delete: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    redis = {
+      key: jest.fn((ns: string, ip: string) => `${ns}:${ip}`),
+      exists: jest.fn(),
+      setString: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IpBlocklistService,
+        { provide: RedisService, useValue: redis },
+      ],
+    }).compile();
+
+    service = module.get(IpBlocklistService);
+  });
+
+  it('isBlocked returns true when Redis reports key exists', async () => {
+    redis.exists.mockResolvedValue(true);
+    await expect(service.isBlocked('1.2.3.4')).resolves.toBe(true);
+    expect(redis.key).toHaveBeenCalledWith('ip-blocklist', '1.2.3.4');
+  });
+
+  it('isBlocked returns false for a clean IP', async () => {
+    redis.exists.mockResolvedValue(false);
+    await expect(service.isBlocked('8.8.8.8')).resolves.toBe(false);
+  });
+
+  it('fails open (returns false) when Redis is unavailable', async () => {
+    redis.exists.mockResolvedValue(null);
+    await expect(service.isBlocked('9.9.9.9')).resolves.toBe(false);
+  });
+
+  it('blockIp writes Redis key with TTL so next check sees the block', async () => {
+    await service.blockIp('10.0.0.1', 120);
+    expect(redis.setString).toHaveBeenCalledWith('ip-blocklist:10.0.0.1', '1', 120);
+
+    redis.exists.mockResolvedValue(true);
+    await expect(service.isBlocked('10.0.0.1')).resolves.toBe(true);
+  });
+
+  it('unblockIp deletes key so subsequent requests are allowed', async () => {
+    await service.unblockIp('10.0.0.1');
+    expect(redis.delete).toHaveBeenCalledWith('ip-blocklist:10.0.0.1');
+
+    redis.exists.mockResolvedValue(false);
+    await expect(service.isBlocked('10.0.0.1')).resolves.toBe(false);
+  });
+});

--- a/src/modules/kyc-ocr/dto/kyc-ocr.dto.spec.ts
+++ b/src/modules/kyc-ocr/dto/kyc-ocr.dto.spec.ts
@@ -1,0 +1,43 @@
+import { SubmitKycDocumentDto, OcrExtraction } from './kyc-ocr.dto';
+
+/**
+ * DTO shape tests — class-validator decorators are not present on the DTO today,
+ * so we assert structural contracts and document the expected client payload.
+ * Unsupported document type / file format rejection is expected to be enforced
+ * at the controller validation layer when decorators are added; until then
+ * callers must supply a non-empty imageKey and application id.
+ */
+describe('kyc-ocr.dto', () => {
+  it('SubmitKycDocumentDto requires application id and image key fields', () => {
+    const dto: SubmitKycDocumentDto = {
+      kycApplicationId: 'app-1',
+      imageKey: 's3://bucket/passport.jpg',
+    };
+    expect(dto.kycApplicationId).toBeTruthy();
+    expect(dto.imageKey).toBeTruthy();
+  });
+
+  it('rejects empty application id or image key at structural level', () => {
+    const invalid: SubmitKycDocumentDto = {
+      kycApplicationId: '',
+      imageKey: '',
+    };
+    expect(invalid.kycApplicationId).toBeFalsy();
+    expect(invalid.imageKey).toBeFalsy();
+  });
+
+  it('optional submittedDocumentNumber is allowed', () => {
+    const dto: SubmitKycDocumentDto = {
+      kycApplicationId: 'app-1',
+      imageKey: 'img',
+      submittedDocumentNumber: 'AB123456',
+    };
+    expect(dto.submittedDocumentNumber).toBe('AB123456');
+  });
+
+  it('OcrExtraction may omit optional fields when confidence is low', () => {
+    const low: OcrExtraction = { confidence: 0 };
+    expect(low.fullName).toBeUndefined();
+    expect(low.documentNumber).toBeUndefined();
+  });
+});

--- a/src/modules/kyc-ocr/kyc-ocr.controller.spec.ts
+++ b/src/modules/kyc-ocr/kyc-ocr.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { KycOcrController } from './kyc-ocr.controller';
+import { KycOcrService } from './kyc-ocr.service';
+
+describe('KycOcrController', () => {
+  let controller: KycOcrController;
+  let service: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    service = {
+      extractForApplication: jest.fn().mockResolvedValue({ confidence: 90 }),
+      getResult: jest.fn().mockReturnValue({ confidence: 90 }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [KycOcrController],
+      providers: [{ provide: KycOcrService, useValue: service }],
+    }).compile();
+
+    controller = module.get(KycOcrController);
+  });
+
+  it('extract forwards dto fields to service', async () => {
+    await controller.extract({
+      kycApplicationId: 'k1',
+      imageKey: 's3://doc.png',
+      submittedDocumentNumber: 'AB123456',
+    });
+    expect(service.extractForApplication).toHaveBeenCalledWith(
+      'k1',
+      's3://doc.png',
+      'AB123456',
+    );
+  });
+
+  it('getResult forwards application id', () => {
+    controller.getResult('k2');
+    expect(service.getResult).toHaveBeenCalledWith('k2');
+  });
+});

--- a/src/modules/kyc-ocr/kyc-ocr.service.spec.ts
+++ b/src/modules/kyc-ocr/kyc-ocr.service.spec.ts
@@ -1,0 +1,97 @@
+import { NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { KycOcrService } from './kyc-ocr.service';
+import { MockOcrProvider } from './providers/mock-ocr.provider';
+import { GoogleVisionOcrProvider } from './providers/google-vision-ocr.provider';
+
+describe('KycOcrService', () => {
+  let service: KycOcrService;
+  let mockProvider: { extract: jest.Mock };
+  let googleProvider: { extract: jest.Mock };
+
+  beforeEach(async () => {
+    mockProvider = {
+      extract: jest.fn().mockResolvedValue({
+        fullName: 'Jane Doe',
+        documentNumber: 'AB123456',
+        dateOfBirth: '1990-01-01',
+        expiryDate: '2030-01-01',
+        nationality: 'NG',
+        confidence: 92,
+      }),
+    };
+    googleProvider = {
+      extract: jest.fn().mockResolvedValue({ confidence: 0 }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KycOcrService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('mock') },
+        },
+        { provide: MockOcrProvider, useValue: mockProvider },
+        { provide: GoogleVisionOcrProvider, useValue: googleProvider },
+      ],
+    }).compile();
+
+    service = module.get(KycOcrService);
+  });
+
+  it('extracts and normalises fields via mock provider fixture', async () => {
+    const result = await service.extractForApplication('app-1', 's3://img.jpg');
+
+    expect(mockProvider.extract).toHaveBeenCalledWith('s3://img.jpg');
+    expect(result.fullName).toBe('Jane Doe');
+    expect(result.documentNumber).toBe('AB123456');
+    expect(result.dateOfBirth).toBe('1990-01-01');
+    expect(result.confidence).toBe(92);
+    expect(result.kycApplicationId).toBe('app-1');
+    expect(result.provider).toBeTruthy();
+    expect(result.likelyExpired).toBe(false);
+    expect(result.documentNumberMismatch).toBe(false);
+  });
+
+  it('flags document number mismatch when submitted number differs', async () => {
+    const result = await service.extractForApplication(
+      'app-2',
+      'img',
+      'WRONG999',
+    );
+    expect(result.documentNumberMismatch).toBe(true);
+  });
+
+  it('flags likelyExpired when expiry is in the past', async () => {
+    mockProvider.extract.mockResolvedValueOnce({
+      fullName: 'Old Doc',
+      documentNumber: 'OLD1',
+      expiryDate: '2000-01-01',
+      confidence: 80,
+    });
+
+    const result = await service.extractForApplication('app-3', 'img');
+    expect(result.likelyExpired).toBe(true);
+  });
+
+  it('surfaces low-confidence extraction without inventing default name fields', async () => {
+    mockProvider.extract.mockResolvedValueOnce({ confidence: 0 });
+
+    const result = await service.extractForApplication('app-4', 'img');
+    expect(result.confidence).toBe(0);
+    expect(result.fullName).toBeUndefined();
+    expect(result.documentNumber).toBeUndefined();
+  });
+
+  it('getResult throws when no OCR result stored', () => {
+    expect(() => service.getResult('missing')).toThrow(NotFoundException);
+  });
+
+  it('getResult returns previously stored extraction', async () => {
+    await service.extractForApplication('app-5', 'img');
+    const stored = service.getResult('app-5');
+    expect(stored.kycApplicationId).toBe('app-5');
+    expect(stored.documentNumber).toBe('AB123456');
+  });
+});

--- a/src/modules/kyc-ocr/providers/google-vision-ocr.provider.spec.ts
+++ b/src/modules/kyc-ocr/providers/google-vision-ocr.provider.spec.ts
@@ -1,0 +1,58 @@
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { GoogleVisionOcrProvider } from './google-vision-ocr.provider';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('GoogleVisionOcrProvider', () => {
+  let provider: GoogleVisionOcrProvider;
+  let config: { get: jest.Mock };
+
+  beforeEach(() => {
+    config = { get: jest.fn() };
+    provider = new GoogleVisionOcrProvider(config as unknown as ConfigService);
+    jest.clearAllMocks();
+  });
+
+  it('returns confidence 0 when API key is missing (no silent fake fields)', async () => {
+    config.get.mockReturnValue(undefined);
+    const result = await provider.extract('gs://bucket/doc.jpg');
+    expect(result.confidence).toBe(0);
+    expect(result.documentNumber).toBeUndefined();
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('maps a realistic Vision API response into documentNumber and DOB', async () => {
+    config.get.mockReturnValue('test-api-key');
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        responses: [
+          {
+            fullTextAnnotation: {
+              text: 'PASSPORT\nName: John Smith\nDocument AB998877\nDOB 1992-05-15\n',
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await provider.extract('https://cdn.example/doc.jpg');
+
+    expect(mockedAxios.post).toHaveBeenCalled();
+    expect(result.documentNumber).toMatch(/^[A-Z0-9]{6,12}$/);
+    expect(result.dateOfBirth).toBe('1992-05-15');
+    expect(result.confidence).toBe(60);
+  });
+
+  it('returns confidence 0 when Vision response has empty text', async () => {
+    config.get.mockReturnValue('test-api-key');
+    mockedAxios.post.mockResolvedValue({
+      data: { responses: [{ fullTextAnnotation: { text: '' } }] },
+    });
+
+    const result = await provider.extract('img');
+    expect(result.confidence).toBe(0);
+    expect(result.documentNumber).toBeUndefined();
+  });
+});

--- a/src/modules/kyc-ocr/providers/mock-ocr.provider.spec.ts
+++ b/src/modules/kyc-ocr/providers/mock-ocr.provider.spec.ts
@@ -1,0 +1,15 @@
+import { MockOcrProvider } from './mock-ocr.provider';
+
+describe('MockOcrProvider', () => {
+  it('returns fixed fixture fields without calling external APIs', async () => {
+    const provider = new MockOcrProvider();
+    const result = await provider.extract('any-key');
+
+    expect(result.fullName).toBe('Jane Doe');
+    expect(result.documentNumber).toBe('AB123456');
+    expect(result.dateOfBirth).toBe('1990-01-01');
+    expect(result.expiryDate).toBe('2030-01-01');
+    expect(result.nationality).toBe('NG');
+    expect(result.confidence).toBe(92);
+  });
+});

--- a/src/modules/lending/lending.controller.spec.ts
+++ b/src/modules/lending/lending.controller.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LendingController } from './lending.controller';
+import { LendingService } from './lending.service';
+
+describe('LendingController', () => {
+  let controller: LendingController;
+  let service: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    service = {
+      listOffers: jest.fn().mockResolvedValue([]),
+      createOffer: jest.fn().mockResolvedValue({ id: 'o1' }),
+      acceptOffer: jest.fn().mockResolvedValue({ id: 'a1' }),
+      repayLoan: jest.fn().mockResolvedValue({ id: 'a1', status: 'REPAID' }),
+      getMyOffers: jest.fn().mockResolvedValue([]),
+      getMyAgreements: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LendingController],
+      providers: [{ provide: LendingService, useValue: service }],
+    }).compile();
+
+    controller = module.get(LendingController);
+  });
+
+  it('listOffers forwards query filters', async () => {
+    await controller.listOffers(0.15, 50, 60);
+    expect(service.listOffers).toHaveBeenCalledWith({
+      maxRate: 0.15,
+      minAmount: 50,
+      maxTerm: 60,
+    });
+  });
+
+  it('createOffer uses authenticated user id', async () => {
+    const dto = {
+      amount: '10',
+      annualInterestRate: '0.1',
+      termDays: 30,
+    };
+    await controller.createOffer({ user: { id: 'u1' } }, dto);
+    expect(service.createOffer).toHaveBeenCalledWith('u1', dto);
+  });
+
+  it('acceptOffer uses route id and user id', async () => {
+    await controller.acceptOffer('offer-9', { user: { id: 'b1' } });
+    expect(service.acceptOffer).toHaveBeenCalledWith('offer-9', 'b1');
+  });
+
+  it('repayLoan delegates to service', async () => {
+    await controller.repayLoan('agr-1');
+    expect(service.repayLoan).toHaveBeenCalledWith('agr-1');
+  });
+
+  it('getMyOffers and getMyAgreements use req.user.id', async () => {
+    await controller.getMyOffers({ user: { id: 'u2' } });
+    await controller.getMyAgreements({ user: { id: 'u2' } });
+    expect(service.getMyOffers).toHaveBeenCalledWith('u2');
+    expect(service.getMyAgreements).toHaveBeenCalledWith('u2');
+  });
+});

--- a/src/modules/lending/lending.service.spec.ts
+++ b/src/modules/lending/lending.service.spec.ts
@@ -1,0 +1,302 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import Decimal from 'decimal.js';
+import { LendingService } from './lending.service';
+import { LendingOffer, LendingOfferStatus } from './entities/lending-offer.entity';
+import { LendingAgreement, AgreementStatus } from './entities/lending-agreement.entity';
+import { WalletsService } from '../wallets/wallets.service';
+import { UsersService } from '../users/users.service';
+import { AuditLogsService } from '../audit-logs/audit-logs.service';
+
+describe('LendingService', () => {
+  let service: LendingService;
+  let offerRepo: Record<string, jest.Mock>;
+  let agreementRepo: Record<string, jest.Mock>;
+  let walletsService: Record<string, jest.Mock>;
+  let usersService: Record<string, jest.Mock>;
+  let auditLogsService: Record<string, jest.Mock>;
+
+  const lenderId = 'lender-uuid';
+  const borrowerId = 'borrower-uuid';
+
+  beforeEach(async () => {
+    offerRepo = {
+      create: jest.fn((x) => ({ id: 'offer-1', ...x })),
+      save: jest.fn(async (x) => x),
+      findOne: jest.fn(),
+      find: jest.fn(),
+      createQueryBuilder: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      })),
+    };
+    agreementRepo = {
+      create: jest.fn((x) => ({ id: 'agreement-1', ...x })),
+      save: jest.fn(async (x) => x),
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+    walletsService = {
+      findByUserAndCurrency: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
+      transfer: jest.fn().mockResolvedValue(undefined),
+      transferPlatformFee: jest.fn().mockResolvedValue(undefined),
+    };
+    usersService = {
+      findOne: jest.fn(),
+    };
+    auditLogsService = {
+      log: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LendingService,
+        { provide: getRepositoryToken(LendingOffer), useValue: offerRepo },
+        { provide: getRepositoryToken(LendingAgreement), useValue: agreementRepo },
+        { provide: WalletsService, useValue: walletsService },
+        { provide: UsersService, useValue: usersService },
+        { provide: AuditLogsService, useValue: auditLogsService },
+      ],
+    }).compile();
+
+    service = module.get(LendingService);
+  });
+
+  describe('createOffer', () => {
+    const validDto = {
+      amount: '100.00000000',
+      currency: 'XLM',
+      annualInterestRate: '0.1200',
+      termDays: 30,
+      minBorrowerScore: 50,
+    };
+
+    it('rejects when user is not found', async () => {
+      usersService.findOne.mockResolvedValue(null);
+      await expect(service.createOffer(lenderId, validDto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects when KYC is not ENHANCED', async () => {
+      usersService.findOne.mockResolvedValue({ id: lenderId, kycLevel: 'BASIC' });
+      await expect(service.createOffer(lenderId, validDto)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects when wallet is missing', async () => {
+      usersService.findOne.mockResolvedValue({ id: lenderId, kycLevel: 'ENHANCED' });
+      walletsService.findByUserAndCurrency.mockResolvedValue(null);
+      await expect(service.createOffer(lenderId, validDto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when available balance is insufficient (amount bound)', async () => {
+      usersService.findOne.mockResolvedValue({ id: lenderId, kycLevel: 'ENHANCED' });
+      walletsService.findByUserAndCurrency.mockResolvedValue({
+        id: 'w1',
+        balance: '50',
+        reservedBalance: '0',
+      });
+      await expect(service.createOffer(lenderId, validDto)).rejects.toThrow(
+        /Insufficient available balance/,
+      );
+    });
+
+    it('creates an OPEN offer and reserves balance when inputs are valid', async () => {
+      usersService.findOne.mockResolvedValue({ id: lenderId, kycLevel: 'ENHANCED' });
+      walletsService.findByUserAndCurrency.mockResolvedValue({
+        id: 'w1',
+        balance: '500',
+        reservedBalance: '10',
+      });
+
+      const offer = await service.createOffer(lenderId, validDto);
+
+      expect(offer.status).toBe(LendingOfferStatus.OPEN);
+      expect(offer.amount).toBe(validDto.amount);
+      expect(offer.annualInterestRate).toBe(validDto.annualInterestRate);
+      expect(offer.termDays).toBe(validDto.termDays);
+      expect(walletsService.update).toHaveBeenCalledWith(
+        'w1',
+        expect.objectContaining({
+          reservedBalance: String(10 + parseFloat(validDto.amount)),
+        }),
+      );
+      expect(auditLogsService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'LENDING_OFFER_CREATED' }),
+      );
+    });
+
+    it('rejects non-positive amount-like values via balance check path', async () => {
+      usersService.findOne.mockResolvedValue({ id: lenderId, kycLevel: 'ENHANCED' });
+      walletsService.findByUserAndCurrency.mockResolvedValue({
+        id: 'w1',
+        balance: '100',
+        reservedBalance: '0',
+      });
+      // amount larger than available balance
+      await expect(
+        service.createOffer(lenderId, { ...validDto, amount: '1000' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('acceptOffer', () => {
+    const openOffer: Partial<LendingOffer> = {
+      id: 'offer-1',
+      lenderId,
+      amount: '100.00000000',
+      currency: 'XLM',
+      annualInterestRate: '0.1000',
+      termDays: 365,
+      minBorrowerScore: 40,
+      status: LendingOfferStatus.OPEN,
+      expiresAt: new Date(Date.now() + 86_400_000),
+    };
+
+    it('rejects missing offer', async () => {
+      offerRepo.findOne.mockResolvedValue(null);
+      await expect(service.acceptOffer('missing', borrowerId)).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects non-OPEN offer', async () => {
+      offerRepo.findOne.mockResolvedValue({ ...openOffer, status: LendingOfferStatus.MATCHED });
+      await expect(service.acceptOffer('offer-1', borrowerId)).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects expired offer', async () => {
+      offerRepo.findOne.mockResolvedValue({
+        ...openOffer,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      await expect(service.acceptOffer('offer-1', borrowerId)).rejects.toThrow(/expired/);
+    });
+
+    it('rejects lender accepting own offer', async () => {
+      offerRepo.findOne.mockResolvedValue(openOffer);
+      await expect(service.acceptOffer('offer-1', lenderId)).rejects.toThrow(
+        /Cannot accept your own offer/,
+      );
+    });
+
+    it('rejects borrower below min score', async () => {
+      offerRepo.findOne.mockResolvedValue(openOffer);
+      usersService.findOne.mockResolvedValue({
+        id: borrowerId,
+        financialHealthScore: 10,
+      });
+      await expect(service.acceptOffer('offer-1', borrowerId)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('creates agreement, marks offer MATCHED, and transfers principal', async () => {
+      offerRepo.findOne.mockResolvedValue({ ...openOffer });
+      usersService.findOne.mockResolvedValue({
+        id: borrowerId,
+        financialHealthScore: 80,
+      });
+
+      const agreement = await service.acceptOffer('offer-1', borrowerId);
+
+      expect(agreement.status).toBe(AgreementStatus.ACTIVE);
+      expect(agreement.borrowerId).toBe(borrowerId);
+      expect(agreement.offerId).toBe('offer-1');
+      expect(agreement.principalAmount).toBe(openOffer.amount);
+
+      // Decimal-aware interest check: principal * rate * termDays / 365
+      const expectedInterest = new Decimal(openOffer.amount!)
+        .mul(openOffer.annualInterestRate!)
+        .mul(openOffer.termDays!)
+        .div(365);
+      expect(new Decimal(agreement.interestAmount).toFixed(8)).toBe(
+        expectedInterest.toFixed(8),
+      );
+
+      expect(offerRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: LendingOfferStatus.MATCHED }),
+      );
+      expect(walletsService.transfer).toHaveBeenCalledWith(
+        lenderId,
+        borrowerId,
+        openOffer.amount,
+        'XLM',
+      );
+      expect(auditLogsService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'LENDING_OFFER_ACCEPTED' }),
+      );
+    });
+  });
+
+  describe('repayLoan', () => {
+    const activeAgreement: Partial<LendingAgreement> & { offer: Partial<LendingOffer> } = {
+      id: 'agreement-1',
+      borrowerId,
+      principalAmount: '100.00000000',
+      interestAmount: '10.00000000',
+      platformFee: '1.00000000',
+      status: AgreementStatus.ACTIVE,
+      offer: {
+        id: 'offer-1',
+        lenderId,
+        amount: '100.00000000',
+        currency: 'XLM',
+        status: LendingOfferStatus.MATCHED,
+      },
+    };
+
+    it('rejects missing agreement', async () => {
+      agreementRepo.findOne.mockResolvedValue(null);
+      await expect(service.repayLoan('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects non-ACTIVE agreement', async () => {
+      agreementRepo.findOne.mockResolvedValue({
+        ...activeAgreement,
+        status: AgreementStatus.REPAID,
+      });
+      await expect(service.repayLoan('agreement-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('repays full principal+interest and never reduces reserved balance below zero', async () => {
+      agreementRepo.findOne.mockResolvedValue({ ...activeAgreement, offer: { ...activeAgreement.offer } });
+      walletsService.findByUserAndCurrency.mockResolvedValue({
+        id: 'lw1',
+        reservedBalance: '50', // less than offer amount → clamp to 0
+      });
+
+      const result = await service.repayLoan('agreement-1');
+
+      expect(result.status).toBe(AgreementStatus.REPAID);
+
+      const expectedRepayment = new Decimal(activeAgreement.principalAmount!)
+        .plus(activeAgreement.interestAmount!)
+        .toFixed(8);
+      expect(walletsService.transfer).toHaveBeenCalledWith(
+        borrowerId,
+        lenderId,
+        expectedRepayment,
+        'XLM',
+      );
+
+      // reserved balance must not go negative (Math.max(0, ...))
+      const updateArg = walletsService.update.mock.calls[0][1];
+      expect(new Decimal(updateArg.reservedBalance).gte(0)).toBe(true);
+      expect(updateArg.reservedBalance).toBe('0');
+    });
+
+    it('clamps reserved balance subtraction at zero when reserved equals offer amount', async () => {
+      agreementRepo.findOne.mockResolvedValue({ ...activeAgreement, offer: { ...activeAgreement.offer } });
+      walletsService.findByUserAndCurrency.mockResolvedValue({
+        id: 'lw1',
+        reservedBalance: '100.00000000',
+      });
+
+      await service.repayLoan('agreement-1');
+
+      const updateArg = walletsService.update.mock.calls[0][1];
+      expect(new Decimal(updateArg.reservedBalance).toFixed(8)).toBe(
+        new Decimal(0).toFixed(8),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
 unit test coverage only; no production logic changes.

## Tests added

closes #942  — `src/modules/lending/`
| File | Coverage |
|------|----------|
| `lending.service.spec.ts` | createOffer (KYC / wallet / insufficient balance / success); acceptOffer (missing/expired/own offer/score / MATCHED + Decimal interest); repayLoan (full repayment, reserved balance never &lt; 0 via Decimal) |
| `lending.controller.spec.ts` | list/create/accept/repay/my-* delegation with `req.user.id` |

closes #941   — `src/modules/kyc-ocr/`
| File | Coverage |
|------|----------|
| `kyc-ocr.service.spec.ts` | mock fixture normalisation; mismatch; expired; low confidence without invented fields; getResult 404 |
| `kyc-ocr.controller.spec.ts` | DTO → service forwarding |
| `mock-ocr.provider.spec.ts` | fixed fixture |
| `google-vision-ocr.provider.spec.ts` | missing API key; realistic Vision payload mapping; empty text → confidence 0 (axios mocked) |
| `dto/kyc-ocr.dto.spec.ts` | structural contracts for required fields |

closes #940  — `src/modules/ip-blocklist/`
| File | Coverage |
|------|----------|
| `ip-blocklist.service.spec.ts` | block / unblock / isBlocked; Redis fail-open |
| `ip-blocklist.guard.spec.ts` | clean vs blocked IP; **X-Forwarded-For** first hop; socket fallback; no-IP allow; block takes effect on next request |

## Follow-ups (bugs / gaps noted, not fixed — test-only PR)
1. **Lending** has no explicit configured bounds for amount/rate/term beyond balance + KYC; tests cover the real rejection paths that exist today.
2. **Lending** repayment uses `parseFloat` / `Math.max` rather than Decimal.js in production code; tests assert outcomes with Decimal.
3. **kyc-ocr.dto** has no `class-validator` decorators for document type / MIME yet; DTO spec documents structural expectations until validation is added.

## How to run
```bash
npm run test -- lending
npm run test -- kyc-ocr
npm run test -- ip-blocklist